### PR TITLE
Feature/parallax bg

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1170,8 +1170,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_xpbd_2d"
-version = "0.3.2"
-source = "git+https://github.com/TheSeekerGame/bevy_xpbd?branch=TheSeeker#46f3189351970c6822af7c095efcbf918bf1480c"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b47df54e811351d51d322543012db78674d2b433f0cefdd9697156cb05afbfe"
 dependencies = [
  "bevy",
  "bevy_xpbd_derive",
@@ -1187,7 +1188,8 @@ dependencies = [
 [[package]]
 name = "bevy_xpbd_derive"
 version = "0.1.0"
-source = "git+https://github.com/TheSeekerGame/bevy_xpbd?branch=TheSeeker#46f3189351970c6822af7c095efcbf918bf1480c"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e1ef1d5e328abe1b76df974245f78e17fd17867583883d5e77444c6a8223a64"
 dependencies = [
  "quote",
  "syn 2.0.48",
@@ -4960,3 +4962,8 @@ dependencies = [
  "quote",
  "syn 2.0.48",
 ]
+
+[[patch.unused]]
+name = "bevy_xpbd_2d"
+version = "0.3.2"
+source = "git+https://github.com/TheSeekerGame/bevy_xpbd?branch=TheSeeker#46f3189351970c6822af7c095efcbf918bf1480c"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1170,9 +1170,8 @@ dependencies = [
 
 [[package]]
 name = "bevy_xpbd_2d"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b47df54e811351d51d322543012db78674d2b433f0cefdd9697156cb05afbfe"
+version = "0.3.2"
+source = "git+https://github.com/TheSeekerGame/bevy_xpbd?branch=TheSeeker#46f3189351970c6822af7c095efcbf918bf1480c"
 dependencies = [
  "bevy",
  "bevy_xpbd_derive",
@@ -1188,8 +1187,7 @@ dependencies = [
 [[package]]
 name = "bevy_xpbd_derive"
 version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e1ef1d5e328abe1b76df974245f78e17fd17867583883d5e77444c6a8223a64"
+source = "git+https://github.com/TheSeekerGame/bevy_xpbd?branch=TheSeeker#46f3189351970c6822af7c095efcbf918bf1480c"
 dependencies = [
  "quote",
  "syn 2.0.48",
@@ -4962,8 +4960,3 @@ dependencies = [
  "quote",
  "syn 2.0.48",
 ]
-
-[[patch.unused]]
-name = "bevy_xpbd_2d"
-version = "0.3.2"
-source = "git+https://github.com/TheSeekerGame/bevy_xpbd?branch=TheSeeker#46f3189351970c6822af7c095efcbf918bf1480c"

--- a/game/src/level.rs
+++ b/game/src/level.rs
@@ -13,6 +13,7 @@
 //! Any of the stuff that actually *happens* within the map when you
 //! play the game, doesn't belong here. Put that stuff under [`crate::game`].
 
+use crate::parallax::{Parallax, ParallaxOrigin};
 use crate::prelude::*;
 
 pub struct LevelManagerPlugin;
@@ -26,6 +27,7 @@ impl Plugin for LevelManagerPlugin {
             OnEnter(AppState::InGame),
             game_level_init,
         );
+        app.add_systems(Update, attach_parallax);
     }
 }
 
@@ -33,7 +35,7 @@ impl Plugin for LevelManagerPlugin {
 fn game_level_init(mut commands: Commands, preloaded: Res<PreloadedAssets>) {
     // TODO: per-level asset management instead of preloaded assets
     // TODO: when we have save files, use that to choose the level to init at
-    
+
     #[cfg(not(feature = "dev"))]
     commands.spawn((
         StateDespawnMarker,
@@ -54,4 +56,31 @@ fn game_level_init(mut commands: Commands, preloaded: Res<PreloadedAssets>) {
             ..Default::default()
         },
     ));
+}
+
+/// attaches parallax components to the different LdtkWorldBundle layers
+fn attach_parallax(
+    mut commands: Commands,
+    query: Query<(Entity, &LayerMetadata), Without<Parallax>>,
+) {
+    for (entity, layer_metadata) in query.iter() {
+        let amount = match &*layer_metadata.identifier {
+            "FarBackground" => 0.3,
+            "MiddleBackground" => 0.2,
+            "NearBackground" => 0.1,
+            _ => {
+                continue;
+            },
+        };
+        println!(
+            "inserted parallax on layer: {}",
+            layer_metadata.identifier
+        );
+        commands.entity(entity).insert((
+            Parallax {
+                depth: 1.0 + amount,
+            },
+            ParallaxOrigin(Vec2::new(88.0, 440.6)),
+        ));
+    }
 }

--- a/game/src/level.rs
+++ b/game/src/level.rs
@@ -72,11 +72,7 @@ fn attach_parallax(
                 continue;
             },
         };
-        println!(
-            "inserted parallax on layer: {}",
-            layer_metadata.identifier
-        );
-        println!("{:?}", layer_metadata);
+
         commands.entity(entity).insert((
             Parallax {
                 depth: 1.0 + amount,

--- a/game/src/level.rs
+++ b/game/src/level.rs
@@ -13,7 +13,7 @@
 //! Any of the stuff that actually *happens* within the map when you
 //! play the game, doesn't belong here. Put that stuff under [`crate::game`].
 
-use crate::parallax::{Parallax, ParallaxOrigin};
+use crate::parallax::{Parallax, ParallaxOffset};
 use crate::prelude::*;
 
 pub struct LevelManagerPlugin;
@@ -76,11 +76,15 @@ fn attach_parallax(
             "inserted parallax on layer: {}",
             layer_metadata.identifier
         );
+        println!("{:?}", layer_metadata);
         commands.entity(entity).insert((
             Parallax {
                 depth: 1.0 + amount,
             },
-            ParallaxOrigin(Vec2::new(88.0, 440.6)),
+            ParallaxOffset(Vec2::new(
+                (layer_metadata.c_wid * layer_metadata.grid_size) as f32 * 0.5,
+                (layer_metadata.c_hei * layer_metadata.grid_size) as f32 * 0.5,
+            )),
         ));
     }
 }

--- a/game/src/main.rs
+++ b/game/src/main.rs
@@ -90,6 +90,7 @@ fn main() {
         crate::ui::UiPlugin,
         crate::camera::CameraPlugin,
         crate::level::LevelManagerPlugin,
+        crate::parallax::ParallaxPlugin,
         crate::game::GameplayPlugin,
         crate::gamestate::GameStatePlugin,
         crate::graphics::GraphicsFxPlugin,

--- a/game/src/main.rs
+++ b/game/src/main.rs
@@ -27,6 +27,7 @@ mod ui;
 #[cfg(feature = "dev")]
 mod dev;
 pub mod graphics;
+mod parallax;
 
 fn main() {
     let mut app = App::new();

--- a/game/src/main.rs
+++ b/game/src/main.rs
@@ -75,8 +75,7 @@ fn main() {
         ProgressPlugin::new(AppState::AssetsLoading)
             .track_assets()
             .continue_to(AppState::MainMenu),
-        // PhysicsPlugins::new(theseeker_engine::time::GameTickUpdate),
-        PhysicsPlugins::default(),
+        PhysicsPlugins::new(theseeker_engine::time::GameTickUpdate),
     ));
 
     // our stuff

--- a/game/src/main.rs
+++ b/game/src/main.rs
@@ -75,7 +75,8 @@ fn main() {
         ProgressPlugin::new(AppState::AssetsLoading)
             .track_assets()
             .continue_to(AppState::MainMenu),
-        PhysicsPlugins::new(theseeker_engine::time::GameTickUpdate),
+        // PhysicsPlugins::new(theseeker_engine::time::GameTickUpdate),
+        PhysicsPlugins::default(),
     ));
 
     // our stuff

--- a/game/src/parallax.rs
+++ b/game/src/parallax.rs
@@ -1,3 +1,5 @@
+use bevy::transform::TransformSystem::TransformPropagate;
+use crate::camera::MainCamera;
 use crate::prelude::*;
 
 /// A simple plugin for applying parallax to entities.
@@ -11,7 +13,7 @@ impl Plugin for ParallaxPlugin {
         // transformations.
         app.add_systems(
             PostUpdate,
-            apply_parallax,
+            apply_parallax.before(TransformPropagate),
         );
     }
 }
@@ -24,7 +26,39 @@ pub struct Parallax {
     pub(crate) depth: f32,
 }
 
-/// System to perform initial setup when entering the gameplay state, load the starting level.
-fn apply_parallax() {
-    // Attach layer trackers
+/// Applies parallax transformations
+fn apply_parallax(
+    mut query: Query<(&mut Transform, &Parallax, &GlobalTransform), Without<MainCamera>>,
+    q_cam: Query<&Transform, (With<MainCamera>)>,
+    mut last_cam_pos: Local<Vec2>,
+    mut runs: Local<u32>,
+) {
+    let Some(cam_trnsfrm) = q_cam.iter().next() else {
+        return;
+    };
+    // Todo: figure out how to either do the camera offset parallax (find center point of bg)
+    //  or figure out how to compensate for all the inititial spawning movements
+    //  (maybe have a global offset tracker for everything with parallax and deterministically
+    //  shift that based on camera's total movements? Wait no, still problem of center not being known...
+    let mut a = false;
+    if *runs < 2 {
+        // Skip the first frame to give time for the transform hierarchies to propagate once.
+        *runs += 1;
+        *last_cam_pos = cam_trnsfrm.translation.xy();
+        return;
+    } else {
+        let delta = cam_trnsfrm.translation.xy() - *last_cam_pos;
+        for (mut transform, parallax, global_transform) in query.iter_mut() {
+            let delta = delta / (parallax.depth);
+            if !a {
+                println!("globl: {}, local: {}", global_transform.translation().xy(), transform.translation.xy());
+                println!("cam: {}", cam_trnsfrm.translation.xy());
+                a = true;
+            }
+            //let pos_final = cam_trnsfrm.translation.xy() + delta;
+            transform.translation.x += delta.x;
+            transform.translation.y += delta.y;
+        }
+        *last_cam_pos = cam_trnsfrm.translation.xy();
+    }
 }

--- a/game/src/parallax.rs
+++ b/game/src/parallax.rs
@@ -1,0 +1,30 @@
+use crate::prelude::*;
+
+/// A simple plugin for applying parallax to entities.
+/// Use by adding this plugin, and attaching the Parallax
+/// component to target entities.
+pub struct ParallaxPlugin;
+
+impl Plugin for ParallaxPlugin {
+    fn build(&self, app: &mut App) {
+        // We run in post update so that changes are applied after any camera
+        // transformations.
+        app.add_systems(
+            PostUpdate,
+            apply_parallax,
+        );
+    }
+}
+
+#[derive(Clone, PartialEq, Debug, Default, Component)]
+pub struct Parallax {
+    /// How far away from the camera is the layer?
+    /// 0 is on top of the camera, 1.0  is "normal distance"
+    /// and larger numbers are background.
+    pub(crate) depth: f32,
+}
+
+/// System to perform initial setup when entering the gameplay state, load the starting level.
+fn apply_parallax() {
+    // Attach layer trackers
+}


### PR DESCRIPTION
Adds parallax affect to backround elements.

Note: from what I could find the parallax percentage set in LDtk doesn't transfer to any of the bevy_ltdk variables, so these percentages are hardcoded in the level.rs file; probably won't be changed but seemed worth noting.