### PR TITLE
Enemy state machine adjustment

### DIFF
--- a/game/src/game/attack/mod.rs
+++ b/game/src/game/attack/mod.rs
@@ -52,16 +52,6 @@ pub struct Health {
     pub max: u32,
 }
 
-#[derive(Component)]
-pub struct DamageFlash {
-    pub current_ticks: u32,
-    pub max_ticks: u32,
-}
-
-// TODO: change to a gentstate once we have death animations
-#[derive(Component)]
-pub struct Dead;
-
 #[derive(Bundle)]
 pub struct AttackBundle {
     attack: Attack,
@@ -90,14 +80,21 @@ impl Attack {
     }
 }
 
-//Component added to attack entity to indicate it causes knockback
+///Component applied to Gfx entity sibling of Gent which has been damaged
+#[derive(Component)]
+pub struct DamageFlash {
+    pub current_ticks: u32,
+    pub max_ticks: u32,
+}
+
+///Component added to attack entity to indicate it causes knockback
 #[derive(Component, Default)]
 pub struct Pushback {
     pub direction: f32,
     pub strength: f32,
 }
 
-//Component added to an entity damaged by a pushback attack
+///Component added to an entity damaged by a pushback attack
 #[derive(Component, Default, Debug)]
 pub struct Knockback {
     pub ticks: u32,
@@ -116,6 +113,11 @@ impl Knockback {
         }
     }
 }
+
+//TODO: change to a gentstate once we have death animations
+///Component applied to an entity when its health was depleted
+#[derive(Component)]
+pub struct Dead;
 
 pub fn attack_damage(
     spatial_query: Res<PhysicsWorld>,
@@ -196,6 +198,8 @@ pub fn attack_damage(
     }
 }
 
+//maybe should not modify velocity directly but add knockback, but this makes it behave differently
+//in states which dont set velocity every frame
 fn knockback(
     mut query: Query<(
         Entity,
@@ -208,7 +212,7 @@ fn knockback(
     for (entity, mut knockback, mut velocity, is_defending) in query.iter_mut() {
         knockback.ticks += 1;
         if !is_defending {
-            velocity.x = knockback.direction * knockback.strength;
+            velocity.x += knockback.direction * knockback.strength;
         }
         if knockback.ticks > knockback.max_ticks {
             velocity.x = 0.;

--- a/game/src/game/player.rs
+++ b/game/src/game/player.rs
@@ -386,7 +386,7 @@ impl Plugin for PlayerBehaviorPlugin {
                 //consider a set for all movement/systems modify velocity, then collisions/move
                 //moves based on velocity
                 (
-                    hitfreeze,
+                    // hitfreeze,
                     set_movement_slots,
                     player_collisions,
                 )

--- a/game/src/game/player.rs
+++ b/game/src/game/player.rs
@@ -761,7 +761,7 @@ fn player_collisions(
                 linear_velocity.length() / time.hz as f32 + 0.5,
                 InteractionGroups {
                     memberships: PLAYER,
-                    filter: GROUND,
+                    filter: Group::from_bits_truncate(0b10010),
                 },
                 Some(entity),
             ) {

--- a/game/src/game/player.rs
+++ b/game/src/game/player.rs
@@ -206,8 +206,8 @@ fn setup_player(
             },
             Facing::Right,
             Health {
-                current: 600,
-                max: 600,
+                current: 1600,
+                max: 1600,
             },
             //have to use builder here *i think* because of different types between keycode and
             //axis


### PR DESCRIPTION
different deaggro behavior, faster transitions to defense/melee attack on melee range, placeholder collisions between enemy and player (only changed collision layers, current strategy for both player and enemy dont account for moving things?)