### PR TITLE
refactor player.rs into a full module

### DIFF
--- a/game/src/game/player/mod.rs
+++ b/game/src/game/player/mod.rs
@@ -1,0 +1,476 @@
+mod player_anim;
+mod player_behaviour;
+
+use bevy::transform::TransformSystem::TransformPropagate;
+use leafwing_input_manager::axislike::VirtualAxis;
+use leafwing_input_manager::prelude::*;
+use player_anim::PlayerAnimationPlugin;
+use player_behaviour::PlayerBehaviorPlugin;
+use rapier2d::geometry::{Group, InteractionGroups};
+use rapier2d::parry::query::TOIStatus;
+use theseeker_engine::animation::SpriteAnimationBundle;
+use theseeker_engine::assets::animation::SpriteAnimation;
+use theseeker_engine::assets::config::{update_field, DynamicConfig};
+use theseeker_engine::gent::{Gent, GentPhysicsBundle, TransformGfxFromGent};
+use theseeker_engine::physics::{
+    into_vec2, AnimationCollider, Collider, LinearVelocity, PhysicsWorld, ShapeCaster, ENEMY,
+    GROUND, PLAYER, PLAYER_ATTACK,
+};
+use theseeker_engine::script::ScriptPlayer;
+
+use crate::game::attack::*;
+use crate::game::gentstate::*;
+use crate::prelude::*;
+
+pub struct PlayerPlugin;
+
+impl Plugin for PlayerPlugin {
+    fn build(&self, app: &mut App) {
+        app.insert_resource(PlayerConfig::default());
+        app.add_systems(GameTickUpdate, load_player_config);
+        app.add_systems(
+            GameTickUpdate,
+            (setup_player.run_if(in_state(GameState::Playing)))
+                .before(PlayerStateSet::Transition)
+                .run_if(in_state(AppState::InGame)),
+        );
+        app.add_systems(
+            OnEnter(GameState::Paused),
+            (
+                debug_player,
+                crate::game::enemy::debug_enemy,
+            )
+                .chain(),
+        )
+        .add_plugins((
+            InputManagerPlugin::<PlayerAction>::default(),
+            PlayerBehaviorPlugin,
+            PlayerTransitionPlugin,
+            PlayerAnimationPlugin,
+        ));
+
+        #[cfg(feature = "dev")]
+        app.add_systems(
+            GameTickUpdate,
+            debug_player_states
+                .run_if(in_state(GameState::Playing))
+                .after(PlayerStateSet::Transition),
+        );
+    }
+}
+
+/// set to order the player behavior, state transitions, and animations relative to eachother
+#[derive(SystemSet, Clone, PartialEq, Eq, Debug, Hash)]
+pub enum PlayerStateSet {
+    Behavior,
+    Collisions,
+    Transition,
+    Animation,
+}
+
+//TODO: change to player spawnpoint
+#[derive(Bundle, LdtkEntity, Default)]
+pub struct PlayerBlueprintBundle {
+    marker: PlayerBlueprint,
+}
+
+#[derive(Bundle)]
+pub struct PlayerGentBundle {
+    player: Player,
+    marker: Gent,
+    phys: GentPhysicsBundle,
+    coyote_time: CoyoteTime,
+}
+
+#[derive(Bundle)]
+pub struct PlayerGfxBundle {
+    marker: PlayerGfx,
+    gent2gfx: TransformGfxFromGent,
+    sprite: SpriteSheetBundle,
+    animation: SpriteAnimationBundle,
+}
+
+#[derive(Component, Default)]
+pub struct PlayerBlueprint;
+
+#[derive(Component)]
+pub struct Player;
+
+#[derive(Component)]
+pub struct PlayerGfx {
+    pub e_gent: Entity,
+}
+
+#[derive(Actionlike, PartialEq, Eq, Clone, Copy, Hash, Debug, Reflect)]
+pub enum PlayerAction {
+    Move,
+    Jump,
+    Attack,
+}
+
+fn debug_player_states(
+    query: Query<
+        AnyOf<(
+            Ref<Running>,
+            Ref<Idle>,
+            Ref<Falling>,
+            Ref<Jumping>,
+            Ref<Grounded>,
+        )>,
+        With<Player>,
+    >,
+) {
+    for states in query.iter() {
+        // println!("{:?}", states);
+        let (running, idle, falling, jumping, grounded) = states;
+        let mut states_string: String = String::new();
+        if let Some(running) = running {
+            if running.is_added() {
+                states_string.push_str("added running, ");
+            }
+        }
+        if let Some(idle) = idle {
+            if idle.is_added() {
+                states_string.push_str("added idle, ");
+            }
+        }
+        if let Some(falling) = falling {
+            if falling.is_added() {
+                states_string.push_str("added falling, ");
+            }
+        }
+        if let Some(jumping) = jumping {
+            if jumping.is_added() {
+                states_string.push_str("added jumping, ");
+            }
+        }
+        if let Some(grounded) = grounded {
+            if grounded.is_added() {
+                states_string.push_str("added grounded, ");
+            }
+        }
+        if !states_string.is_empty() {
+            println!("{}", states_string);
+        }
+
+        // let components = entity.archetype().sparse_set_components();
+        // for item in components {
+        // print!("{:?}", item);
+        // }
+    }
+}
+
+// fn debug_player(world: &World, query: Query<Entity, With<PlayerGfx>>) {
+fn debug_player(world: &World, query: Query<Entity, With<Player>>) {
+    for entity in query.iter() {
+        let components = world.inspect_entity(entity);
+        for component in components.iter() {
+            println!("{:?}", component.name());
+        }
+    }
+}
+
+fn setup_player(
+    mut q: Query<(&mut Transform, Entity), Added<PlayerBlueprint>>,
+    mut commands: Commands,
+) {
+    for (mut xf_gent, e_gent) in q.iter_mut() {
+        //TODO: proper way of ensuring z is correct
+        xf_gent.translation.z = 15.;
+        println!("{:?}", xf_gent);
+        let e_gfx = commands.spawn(()).id();
+        commands.entity(e_gent).insert((
+            Name::new("Player"),
+            PlayerGentBundle {
+                player: Player,
+                marker: Gent { e_gfx },
+                phys: GentPhysicsBundle {
+                    collider: Collider::cuboid(
+                        4.0,
+                        10.0,
+                        InteractionGroups {
+                            memberships: PLAYER,
+                            //should be more specific
+                            filter: Group::all(),
+                        },
+                    ),
+                    shapecast: ShapeCaster {
+                        shape: Collider::cuboid(4.0, 10.0, InteractionGroups::none())
+                            .0
+                            .shared_shape()
+                            .clone(),
+                        origin: Vec2::new(0.0, 0.0),
+                        max_toi: f32::MAX,
+                        direction: Direction2d::NEG_Y,
+                        interaction: InteractionGroups {
+                            memberships: PLAYER,
+                            filter: GROUND,
+                        },
+                    },
+                    linear_velocity: LinearVelocity(Vec2::ZERO),
+                },
+                coyote_time: Default::default(),
+            },
+            Facing::Right,
+            Health {
+                current: 1600,
+                max: 1600,
+            },
+            //have to use builder here *i think* because of different types between keycode and
+            //axis
+            InputManagerBundle::<PlayerAction> {
+                action_state: ActionState::default(),
+                input_map: InputMap::default()
+                    .insert(PlayerAction::Jump, KeyCode::Space)
+                    .insert(PlayerAction::Jump, KeyCode::KeyW)
+                    .insert(PlayerAction::Jump, KeyCode::ArrowUp)
+                    .insert(
+                        PlayerAction::Move,
+                        VirtualAxis::from_keys(KeyCode::KeyA, KeyCode::KeyD),
+                    )
+                    .insert(
+                        PlayerAction::Move,
+                        VirtualAxis::from_keys(KeyCode::ArrowLeft, KeyCode::ArrowRight),
+                    )
+                    .insert(PlayerAction::Attack, KeyCode::Enter)
+                    .insert(PlayerAction::Attack, KeyCode::KeyJ)
+                    .build(),
+            },
+            Falling,
+            WallSlideTime(f32::MAX),
+            HitFreezeTime(u32::MAX, None),
+            TransitionQueue::default(),
+        ));
+        commands.entity(e_gfx).insert((PlayerGfxBundle {
+            marker: PlayerGfx { e_gent },
+            gent2gfx: TransformGfxFromGent {
+                pixel_aligned: false,
+                gent: e_gent,
+            },
+            sprite: SpriteSheetBundle {
+                transform: *xf_gent,
+                ..Default::default()
+            },
+            animation: Default::default(),
+        },));
+        // println!("player spawned")
+    }
+}
+
+struct PlayerTransitionPlugin;
+
+impl Plugin for PlayerTransitionPlugin {
+    fn build(&self, app: &mut App) {
+        app.add_systems(
+            GameTickUpdate,
+            (transition.run_if(any_with_component::<TransitionQueue>),)
+                .in_set(PlayerStateSet::Transition)
+                .after(PlayerStateSet::Behavior)
+                .run_if(in_state(AppState::InGame)),
+        );
+    }
+}
+
+// States
+// states are components which are added to the entity on transition.
+// an entity can be in multiple states at once, eg Grounded and Running/Idle
+// Impl Playerstate for each state
+// Impl Transitionable<T: GentState> for each state that that should be able to be transitioned
+// from by a state
+// pub trait GentState: Component<Storage = SparseStorage> {}
+
+#[derive(Component, Default, Debug)]
+#[component(storage = "SparseSet")]
+pub struct Idle;
+impl GentState for Idle {}
+impl GenericState for Idle {}
+
+#[derive(Component, Default, Debug)]
+#[component(storage = "SparseSet")]
+pub struct Running;
+impl GentState for Running {}
+impl GenericState for Running {}
+
+#[derive(Component, Default, Debug)]
+#[component(storage = "SparseSet")]
+pub struct Falling;
+impl GentState for Falling {}
+impl GenericState for Falling {}
+
+#[derive(Component, Debug)]
+#[component(storage = "SparseSet")]
+pub struct Jumping;
+impl GentState for Jumping {}
+impl GenericState for Jumping {}
+
+#[derive(Component, Default, Debug)]
+#[component(storage = "SparseSet")]
+pub struct Grounded;
+impl GentState for Grounded {}
+//cant be Idle or Running if not Grounded
+impl Transitionable<Jumping> for Grounded {
+    type Removals = (Grounded, Idle, Running);
+}
+//cant be Idle or Running if not Grounded
+impl Transitionable<Falling> for Grounded {
+    type Removals = (Grounded, Idle, Running);
+}
+
+#[derive(Component, Debug, Default)]
+#[component(storage = "SparseSet")]
+pub struct Attacking {
+    ticks: u32,
+}
+impl Attacking {
+    const MAX: u32 = 4;
+    const STARTUP: u32 = 0;
+}
+impl GentState for Attacking {}
+
+impl Transitionable<CanAttack> for Attacking {
+    type Removals = (Attacking);
+}
+
+#[derive(Component, Debug, Default)]
+#[component(storage = "SparseSet")]
+pub struct CanAttack;
+impl GentState for CanAttack {}
+
+impl Transitionable<Attacking> for CanAttack {
+    type Removals = (CanAttack);
+}
+
+// Pseudo-States
+// Not quite the same as states, these components enable certain behaviours when attached,
+// and provide storage for that behaviours state
+
+/// If a player attack lands, locks their velocity for the configured number of ticks'
+//Tracks the attack entity which last caused the hirfreeze affect. (this way the same attack
+// doesn't trigger it muyltiple times)
+#[derive(Component, Default, Debug)]
+pub struct HitFreezeTime(u32, Option<Entity>);
+
+#[derive(Component, Default, Debug)]
+pub struct CoyoteTime(f32);
+
+/// Indicates that sliding is tracked for this entity
+#[derive(Component, Default, Debug)]
+pub struct WallSlideTime(f32);
+impl WallSlideTime {
+    /// Player is sliding if f32 value is less then the coyote time
+    /// f32 starts incrementing when the player stops pressing into the wall
+    fn sliding(&self, cfg: &PlayerConfig) -> bool {
+        self.0 <= cfg.max_coyote_time * 2.0
+    }
+}
+
+#[derive(Resource, Debug, Default)]
+pub struct PlayerConfig {
+    /// The maximum horizontal velocity the player can move at.
+    ///
+    /// (in pixels/second)
+    max_move_vel: f32,
+
+    /// The maximum downward velocity the player can fall at.
+    ///
+    /// (in pixels/second)
+    max_fall_vel: f32,
+
+    /// The initial acceleration applied to the player for the first tick they start moving.
+    ///
+    /// (in pixels/second^2)
+    move_accel_init: f32,
+
+    /// The acceleration applied to the player while they continue moving horizontally.
+    ///
+    /// (in pixels/second^2)
+    move_accel: f32,
+
+    /// How much velocity does the player have at the moment they jump?
+    ///
+    /// (in pixels/second)
+    jump_vel_init: f32,
+
+    /// How fast does the player accelerate downward while holding down the jump button?
+    ///
+    /// (in pixels/second^2)
+    jump_fall_accel: f32,
+
+    /// How fast does the player accelerate downward while in the falling state?
+    /// (ie: after releasing the jump key)
+    ///
+    /// (in pixels/second^2)
+    /// Note: sets the games global_gravity! (affects projectiles and other things that fall)
+    pub fall_accel: f32,
+
+    /// How many seconds does our characters innate hover boots work?
+    max_coyote_time: f32,
+
+    /// Onlly applies in the downward y direction while the player is falling
+    /// and trying to walk into the wall
+    sliding_friction: f32,
+
+    /// How many ticks is the players velocity locked to zero after landing an attack?
+    hitfreeze_ticks: u32,
+}
+
+fn load_player_config(
+    mut ev_asset: EventReader<AssetEvent<DynamicConfig>>,
+    cfgs: Res<Assets<DynamicConfig>>,
+    preloaded: Res<PreloadedAssets>,
+    mut player_config: ResMut<PlayerConfig>,
+    mut commands: Commands,
+    mut initialized_config: Local<bool>,
+) {
+    // convert from asset key string to bevy handle
+    let Some(cfg_handle) = preloaded.get_single_asset::<DynamicConfig>("cfg.player") else {
+        return;
+    };
+    // The reason we do this here instead of in an AssetEvent::Added match arm, is because
+    // the Added match arm fires before preloaded updates with the asset key; as a result
+    // you can't tell what specific DynamicConfig loaded in like that.
+    if !*initialized_config {
+        if let Some(cfg) = cfgs.get(cfg_handle.clone()) {
+            update_player_config(&mut player_config, cfg);
+            println!("init:");
+            dbg!(&player_config);
+        }
+        *initialized_config = true;
+    }
+    for ev in ev_asset.read() {
+        match ev {
+            AssetEvent::Modified { id } => {
+                if let Some(cfg) = cfgs.get(*id) {
+                    if cfg_handle.id() == *id {
+                        println!("before:");
+                        dbg!(&player_config);
+                        update_player_config(&mut player_config, cfg);
+                        println!("after:");
+                        dbg!(&player_config);
+                    }
+                }
+            },
+            _ => {},
+        }
+    }
+}
+
+#[rustfmt::skip]
+fn update_player_config(config: &mut PlayerConfig, cfg: &DynamicConfig) {
+    let mut errors = Vec::new();
+
+    update_field(&mut errors, &cfg.0, "max_move_vel", |val| config.max_move_vel = val);
+    update_field(&mut errors, &cfg.0, "max_fall_vel", |val| config.max_fall_vel = val);
+    update_field(&mut errors, &cfg.0, "move_accel_init", |val| config.move_accel_init = val);
+    update_field(&mut errors, &cfg.0, "move_accel", |val| config.move_accel = val);
+    update_field(&mut errors, &cfg.0, "jump_vel_init", |val| config.jump_vel_init = val);
+    update_field(&mut errors, &cfg.0, "jump_fall_accel", |val| config.jump_fall_accel = val);
+    update_field(&mut errors, &cfg.0, "fall_accel", |val| config.fall_accel = val);
+    update_field(&mut errors, &cfg.0, "max_coyote_time", |val| config.max_coyote_time = val);
+    update_field(&mut errors, &cfg.0, "sliding_friction", |val| config.sliding_friction = val);
+    update_field(&mut errors, &cfg.0, "hitfreeze_ticks", |val| config.hitfreeze_ticks = val as u32);
+
+   for error in errors{
+       warn!("failed to load player cfg value: {}", error);
+   }
+}

--- a/game/src/game/player/player_anim.rs
+++ b/game/src/game/player/player_anim.rs
@@ -1,0 +1,199 @@
+use crate::appstate::AppState;
+use crate::game::gentstate::Facing;
+use crate::game::player::{
+    Attacking, CanAttack, Falling, HitFreezeTime, Idle, Jumping, PlayerConfig, PlayerGfx,
+    PlayerStateSet, Running, WallSlideTime,
+};
+use crate::prelude::{
+    in_state, Added, App, Has, IntoSystemConfigs, Local, Or, Plugin, Query, Res, With, Without,
+};
+use theseeker_engine::assets::animation::SpriteAnimation;
+use theseeker_engine::gent::Gent;
+use theseeker_engine::prelude::{GameTickUpdate, GameTime};
+use theseeker_engine::script::ScriptPlayer;
+
+///play animations here, run after transitions
+pub struct PlayerAnimationPlugin;
+
+impl Plugin for PlayerAnimationPlugin {
+    fn build(&self, app: &mut App) {
+        app.add_systems(
+            GameTickUpdate,
+            (
+                player_idle_animation,
+                player_falling_animation,
+                player_jumping_animation,
+                player_running_animation,
+                player_attacking_animation,
+                sprite_flip.after(player_attacking_animation),
+            )
+                .in_set(PlayerStateSet::Animation)
+                .after(PlayerStateSet::Transition)
+                .run_if(in_state(AppState::InGame)),
+        );
+    }
+}
+
+fn player_idle_animation(
+    i_query: Query<
+        &Gent,
+        Or<(
+            (Added<Idle>, Without<Attacking>),
+            (With<Idle>, Added<CanAttack>),
+        )>,
+    >,
+    mut gfx_query: Query<&mut ScriptPlayer<SpriteAnimation>, With<PlayerGfx>>,
+) {
+    for gent in i_query.iter() {
+        if let Ok(mut player) = gfx_query.get_mut(gent.e_gfx) {
+            player.play_key("anim.player.Idle")
+        }
+    }
+}
+
+fn player_falling_animation(
+    f_query: Query<
+        (&Gent, Option<&WallSlideTime>),
+        Or<(
+            (With<Falling>, Without<Attacking>),
+            (With<Falling>, Added<CanAttack>),
+        )>,
+    >,
+    mut gfx_query: Query<&mut ScriptPlayer<SpriteAnimation>, With<PlayerGfx>>,
+    config: Res<PlayerConfig>,
+) {
+    for (gent, sliding) in f_query.iter() {
+        if let Ok(mut player) = gfx_query.get_mut(gent.e_gfx) {
+            if let Some(sliding) = sliding {
+                if sliding.sliding(&config) {
+                    if player.current_key().unwrap_or("") != "anim.player.WallSlide" {
+                        player.play_key("anim.player.WallSlide");
+                    }
+                } else {
+                    if player.current_key().unwrap_or("") != "anim.player.Fall" {
+                        player.play_key("anim.player.Fall");
+                    }
+                }
+            } else {
+                if player.current_key().unwrap_or("") != "anim.player.Fall" {
+                    player.play_key("anim.player.Fall");
+                }
+            }
+        }
+    }
+}
+
+fn player_jumping_animation(
+    f_query: Query<
+        &Gent,
+        Or<(
+            (Added<Jumping>, Without<Attacking>),
+            (With<Jumping>, Added<CanAttack>),
+        )>,
+    >,
+    mut gfx_query: Query<&mut ScriptPlayer<SpriteAnimation>, With<PlayerGfx>>,
+) {
+    for gent in f_query.iter() {
+        if let Ok(mut player) = gfx_query.get_mut(gent.e_gfx) {
+            player.play_key("anim.player.Jump")
+        }
+    }
+}
+
+fn player_running_animation(
+    r_query: Query<
+        &Gent,
+        Or<(
+            (Added<Running>, Without<Attacking>),
+            (With<Running>, Added<CanAttack>),
+        )>,
+    >,
+    mut gfx_query: Query<&mut ScriptPlayer<SpriteAnimation>, With<PlayerGfx>>,
+) {
+    for gent in r_query.iter() {
+        if let Ok(mut player) = gfx_query.get_mut(gent.e_gfx) {
+            player.play_key("anim.player.Run")
+        }
+    }
+}
+
+fn player_attacking_animation(
+    r_query: Query<
+        (
+            &Gent,
+            Has<Falling>,
+            Has<Jumping>,
+            Has<Running>,
+            Option<&HitFreezeTime>,
+        ),
+        Added<Attacking>,
+    >,
+    mut gfx_query: Query<&mut ScriptPlayer<SpriteAnimation>, With<PlayerGfx>>,
+    config: Res<PlayerConfig>,
+) {
+    for (gent, is_falling, is_jumping, is_running, hitfrozen) in r_query.iter() {
+        if let Ok(mut player) = gfx_query.get_mut(gent.e_gfx) {
+            let hitfrozen = hitfrozen
+                .map(|f| f.0 < config.hitfreeze_ticks)
+                .unwrap_or(false);
+            if is_falling || is_jumping {
+                player.play_key("anim.player.SwordBasicAir")
+            } else if is_running && !hitfrozen {
+                player.play_key("anim.player.SwordBasicRun")
+            } else {
+                player.play_key("anim.player.SwordBasicIdle")
+            }
+        }
+    }
+    //have to check if first or 2nd attack, play diff anim
+    //also check for up attack?
+}
+
+fn sprite_flip(
+    query: Query<(&Facing, &Gent, Option<&WallSlideTime>)>,
+    mut gfx_query: Query<&mut ScriptPlayer<SpriteAnimation>, With<PlayerGfx>>,
+    mut current_direction: Local<bool>,
+    mut old_direction: Local<bool>,
+    time: Res<GameTime>,
+) {
+    for (facing, gent, wall_slide_time) in query.iter() {
+        if let Ok(mut player) = gfx_query.get_mut(gent.e_gfx) {
+            *old_direction = *current_direction;
+            let mut facing = facing.clone();
+
+            // Have the player face away from the wall if they are attacking while wall sliding
+            let pressed_on_wall = wall_slide_time
+                // checks that player is actually against the wall, rather then it being close
+                // enough time from the player having left the wall to still jump
+                // (ie: not wall_jump_coyote_time)
+                .map(|s| s.0 <= 1.0 / time.hz as f32)
+                .unwrap_or(false);
+            if pressed_on_wall && player.current_key() == Some("anim.player.SwordBasicAir") {
+                facing = match facing {
+                    Facing::Right => Facing::Left,
+                    Facing::Left => Facing::Right,
+                }
+            }
+            match facing {
+                Facing::Right => {
+                    //TODO: toggle facing script action
+                    player.set_slot("DirectionRight", true);
+                    player.set_slot("DirectionLeft", false);
+                    *current_direction = true;
+                },
+                Facing::Left => {
+                    player.set_slot("DirectionRight", false);
+                    player.set_slot("DirectionLeft", true);
+                    *current_direction = false;
+                },
+            }
+
+            // lazy change detection cause I can't be asked to learn proper bevy way lel ~c12
+            if *old_direction != *current_direction {
+                player.set_slot("DirectionChanged", true);
+            } else {
+                player.set_slot("DirectionChanged", false);
+            }
+        }
+    }
+}

--- a/game/src/game/player/player_behaviour.rs
+++ b/game/src/game/player/player_behaviour.rs
@@ -108,7 +108,7 @@ fn hitfreeze(
     }
 }
 
-pub fn player_idle(
+fn player_idle(
     mut query: Query<
         (
             &ActionState<PlayerAction>,
@@ -132,7 +132,7 @@ pub fn player_idle(
     }
 }
 
-pub fn player_move(
+fn player_move(
     config: Res<PlayerConfig>,
     mut q_gent: Query<
         (
@@ -188,7 +188,7 @@ pub fn player_move(
     }
 }
 
-pub fn set_movement_slots(
+fn set_movement_slots(
     mut q_gent: Query<(&LinearVelocity, &Gent), (With<Player>)>,
     mut q_gfx_player: Query<&mut ScriptPlayer<SpriteAnimation>, With<PlayerGfx>>,
 ) {
@@ -221,7 +221,7 @@ pub fn set_movement_slots(
     }
 }
 
-pub fn player_run(
+fn player_run(
     mut q_gent: Query<
         (
             &ActionState<PlayerAction>,
@@ -247,7 +247,7 @@ pub fn player_run(
     }
 }
 
-pub fn player_jump(
+fn player_jump(
     mut query: Query<
         (
             &ActionState<PlayerAction>,
@@ -279,7 +279,7 @@ pub fn player_jump(
     }
 }
 
-pub fn player_collisions(
+fn player_collisions(
     spatial_query: Res<PhysicsWorld>,
     mut q_gent: Query<
         (
@@ -435,7 +435,7 @@ pub fn player_collisions(
 /// Needs to be non-zero to avoid getting stuck in the ground.
 const GROUNDED_THRESHOLD: f32 = 1.0;
 
-pub fn player_grounded(
+fn player_grounded(
     spatial_query: Res<PhysicsWorld>,
     mut query: Query<
         (
@@ -502,7 +502,7 @@ pub fn player_grounded(
     }
 }
 
-pub fn player_falling(
+fn player_falling(
     spatial_query: Res<PhysicsWorld>,
     mut query: Query<
         (
@@ -551,7 +551,7 @@ pub fn player_falling(
     }
 }
 
-pub fn player_sliding(
+fn player_sliding(
     mut query: Query<(
         &Gent,
         &ActionState<PlayerAction>,
@@ -581,7 +581,7 @@ pub fn player_sliding(
     }
 }
 
-pub fn add_attack(
+fn add_attack(
     mut query: Query<
         (
             &mut TransitionQueue,
@@ -599,7 +599,7 @@ pub fn add_attack(
     }
 }
 
-pub fn player_attack(
+fn player_attack(
     mut query: Query<
         (
             Entity,

--- a/game/src/game/player/player_behaviour.rs
+++ b/game/src/game/player/player_behaviour.rs
@@ -1,371 +1,36 @@
+use crate::game::attack::{Attack, Pushback};
+use crate::game::enemy::Enemy;
+use crate::game::gentstate::{Facing, TransitionQueue, Transitionable};
+use crate::game::player::{
+    Attacking, CanAttack, CoyoteTime, Falling, Grounded, HitFreezeTime, Idle, Jumping, Player,
+    PlayerAction, PlayerConfig, PlayerGfx, PlayerStateSet, Running, WallSlideTime,
+};
+use crate::prelude::{
+    any_with_component, App, BuildChildren, Commands, DetectChanges, Direction2d, Entity,
+    IntoSystemConfigs, Plugin, Query, Res, Transform, TransformBundle, With, Without,
+};
 use bevy::transform::TransformSystem::TransformPropagate;
-use leafwing_input_manager::axislike::VirtualAxis;
-use leafwing_input_manager::prelude::*;
+use glam::{Vec2, Vec2Swizzles, Vec3Swizzles};
+use leafwing_input_manager::action_state::ActionState;
 use rapier2d::geometry::{Group, InteractionGroups};
 use rapier2d::parry::query::TOIStatus;
-use theseeker_engine::animation::SpriteAnimationBundle;
 use theseeker_engine::assets::animation::SpriteAnimation;
-use theseeker_engine::assets::config::{update_field, DynamicConfig};
-use theseeker_engine::gent::{Gent, GentPhysicsBundle, TransformGfxFromGent};
+use theseeker_engine::condition::any_matching;
+use theseeker_engine::gent::Gent;
 use theseeker_engine::physics::{
     into_vec2, AnimationCollider, Collider, LinearVelocity, PhysicsWorld, ShapeCaster, ENEMY,
     GROUND, PLAYER, PLAYER_ATTACK,
 };
+use theseeker_engine::prelude::{GameTickUpdate, GameTime};
 use theseeker_engine::script::ScriptPlayer;
-
-use crate::game::attack::*;
-use crate::game::gentstate::*;
-use crate::prelude::*;
-
-pub struct PlayerPlugin;
-
-impl Plugin for PlayerPlugin {
-    fn build(&self, app: &mut App) {
-        app.add_systems(
-            GameTickUpdate,
-            (setup_player.run_if(in_state(GameState::Playing)))
-                .before(PlayerStateSet::Transition)
-                .run_if(in_state(AppState::InGame)),
-        );
-        app.add_systems(
-            OnEnter(GameState::Paused),
-            (
-                debug_player,
-                crate::game::enemy::debug_enemy,
-            )
-                .chain(),
-        )
-        .add_plugins((
-            InputManagerPlugin::<PlayerAction>::default(),
-            PlayerBehaviorPlugin,
-            PlayerTransitionPlugin,
-            PlayerAnimationPlugin,
-        ));
-
-        #[cfg(feature = "dev")]
-        app.add_systems(
-            GameTickUpdate,
-            debug_player_states
-                .run_if(in_state(GameState::Playing))
-                .after(PlayerStateSet::Transition),
-        );
-    }
-}
-
-/// set to order the player behavior, state transitions, and animations relative to eachother
-#[derive(SystemSet, Clone, PartialEq, Eq, Debug, Hash)]
-pub enum PlayerStateSet {
-    Behavior,
-    Collisions,
-    Transition,
-    Animation,
-}
-
-//TODO: change to player spawnpoint
-#[derive(Bundle, LdtkEntity, Default)]
-pub struct PlayerBlueprintBundle {
-    marker: PlayerBlueprint,
-}
-
-#[derive(Bundle)]
-pub struct PlayerGentBundle {
-    player: Player,
-    marker: Gent,
-    phys: GentPhysicsBundle,
-    coyote_time: CoyoteTime,
-}
-
-#[derive(Bundle)]
-pub struct PlayerGfxBundle {
-    marker: PlayerGfx,
-    gent2gfx: TransformGfxFromGent,
-    sprite: SpriteSheetBundle,
-    animation: SpriteAnimationBundle,
-}
-
-#[derive(Component, Default)]
-pub struct PlayerBlueprint;
-
-#[derive(Component)]
-pub struct Player;
-
-#[derive(Component)]
-pub struct PlayerGfx {
-    pub e_gent: Entity,
-}
-
-#[derive(Actionlike, PartialEq, Eq, Clone, Copy, Hash, Debug, Reflect)]
-pub enum PlayerAction {
-    Move,
-    Jump,
-    Attack,
-}
-
-fn debug_player_states(
-    query: Query<
-        AnyOf<(
-            Ref<Running>,
-            Ref<Idle>,
-            Ref<Falling>,
-            Ref<Jumping>,
-            Ref<Grounded>,
-        )>,
-        With<Player>,
-    >,
-) {
-    for states in query.iter() {
-        // println!("{:?}", states);
-        let (running, idle, falling, jumping, grounded) = states;
-        let mut states_string: String = String::new();
-        if let Some(running) = running {
-            if running.is_added() {
-                states_string.push_str("added running, ");
-            }
-        }
-        if let Some(idle) = idle {
-            if idle.is_added() {
-                states_string.push_str("added idle, ");
-            }
-        }
-        if let Some(falling) = falling {
-            if falling.is_added() {
-                states_string.push_str("added falling, ");
-            }
-        }
-        if let Some(jumping) = jumping {
-            if jumping.is_added() {
-                states_string.push_str("added jumping, ");
-            }
-        }
-        if let Some(grounded) = grounded {
-            if grounded.is_added() {
-                states_string.push_str("added grounded, ");
-            }
-        }
-        if !states_string.is_empty() {
-            println!("{}", states_string);
-        }
-
-        // let components = entity.archetype().sparse_set_components();
-        // for item in components {
-        // print!("{:?}", item);
-        // }
-    }
-}
-
-// fn debug_player(world: &World, query: Query<Entity, With<PlayerGfx>>) {
-fn debug_player(world: &World, query: Query<Entity, With<Player>>) {
-    for entity in query.iter() {
-        let components = world.inspect_entity(entity);
-        for component in components.iter() {
-            println!("{:?}", component.name());
-        }
-    }
-}
-
-fn setup_player(
-    mut q: Query<(&mut Transform, Entity), Added<PlayerBlueprint>>,
-    mut commands: Commands,
-) {
-    for (mut xf_gent, e_gent) in q.iter_mut() {
-        //TODO: proper way of ensuring z is correct
-        xf_gent.translation.z = 15.;
-        println!("{:?}", xf_gent);
-        let e_gfx = commands.spawn(()).id();
-        commands.entity(e_gent).insert((
-            Name::new("Player"),
-            PlayerGentBundle {
-                player: Player,
-                marker: Gent { e_gfx },
-                phys: GentPhysicsBundle {
-                    collider: Collider::cuboid(
-                        4.0,
-                        10.0,
-                        InteractionGroups {
-                            memberships: PLAYER,
-                            //should be more specific
-                            filter: Group::all(),
-                        },
-                    ),
-                    shapecast: ShapeCaster {
-                        shape: Collider::cuboid(4.0, 10.0, InteractionGroups::none())
-                            .0
-                            .shared_shape()
-                            .clone(),
-                        origin: Vec2::new(0.0, 0.0),
-                        max_toi: f32::MAX,
-                        direction: Direction2d::NEG_Y,
-                        interaction: InteractionGroups {
-                            memberships: PLAYER,
-                            filter: GROUND,
-                        },
-                    },
-                    linear_velocity: LinearVelocity(Vec2::ZERO),
-                },
-                coyote_time: Default::default(),
-            },
-            Facing::Right,
-            Health {
-                current: 1600,
-                max: 1600,
-            },
-            //have to use builder here *i think* because of different types between keycode and
-            //axis
-            InputManagerBundle::<PlayerAction> {
-                action_state: ActionState::default(),
-                input_map: InputMap::default()
-                    .insert(PlayerAction::Jump, KeyCode::Space)
-                    .insert(PlayerAction::Jump, KeyCode::KeyW)
-                    .insert(PlayerAction::Jump, KeyCode::ArrowUp)
-                    .insert(
-                        PlayerAction::Move,
-                        VirtualAxis::from_keys(KeyCode::KeyA, KeyCode::KeyD),
-                    )
-                    .insert(
-                        PlayerAction::Move,
-                        VirtualAxis::from_keys(KeyCode::ArrowLeft, KeyCode::ArrowRight),
-                    )
-                    .insert(PlayerAction::Attack, KeyCode::Enter)
-                    .insert(PlayerAction::Attack, KeyCode::KeyJ)
-                    .build(),
-            },
-            Falling,
-            WallSlideTime(f32::MAX),
-            HitFreezeTime(u32::MAX, None),
-            TransitionQueue::default(),
-        ));
-        commands.entity(e_gfx).insert((PlayerGfxBundle {
-            marker: PlayerGfx { e_gent },
-            gent2gfx: TransformGfxFromGent {
-                pixel_aligned: false,
-                gent: e_gent,
-            },
-            sprite: SpriteSheetBundle {
-                transform: *xf_gent,
-                ..Default::default()
-            },
-            animation: Default::default(),
-        },));
-        // println!("player spawned")
-    }
-}
-
-struct PlayerTransitionPlugin;
-
-impl Plugin for PlayerTransitionPlugin {
-    fn build(&self, app: &mut App) {
-        app.add_systems(
-            GameTickUpdate,
-            (transition.run_if(any_with_component::<TransitionQueue>),)
-                .in_set(PlayerStateSet::Transition)
-                .after(PlayerStateSet::Behavior)
-                .run_if(in_state(AppState::InGame)),
-        );
-    }
-}
-
-// States
-// states are components which are added to the entity on transition.
-// an entity can be in multiple states at once, eg Grounded and Running/Idle
-// Impl Playerstate for each state
-// Impl Transitionable<T: GentState> for each state that that should be able to be transitioned
-// from by a state
-// pub trait GentState: Component<Storage = SparseStorage> {}
-
-#[derive(Component, Default, Debug)]
-#[component(storage = "SparseSet")]
-pub struct Idle;
-impl GentState for Idle {}
-impl GenericState for Idle {}
-
-#[derive(Component, Default, Debug)]
-#[component(storage = "SparseSet")]
-pub struct Running;
-impl GentState for Running {}
-impl GenericState for Running {}
-
-#[derive(Component, Default, Debug)]
-#[component(storage = "SparseSet")]
-pub struct Falling;
-impl GentState for Falling {}
-impl GenericState for Falling {}
-
-#[derive(Component, Debug)]
-#[component(storage = "SparseSet")]
-pub struct Jumping;
-impl GentState for Jumping {}
-impl GenericState for Jumping {}
-
-#[derive(Component, Default, Debug)]
-#[component(storage = "SparseSet")]
-pub struct Grounded;
-impl GentState for Grounded {}
-//cant be Idle or Running if not Grounded
-impl Transitionable<Jumping> for Grounded {
-    type Removals = (Grounded, Idle, Running);
-}
-//cant be Idle or Running if not Grounded
-impl Transitionable<Falling> for Grounded {
-    type Removals = (Grounded, Idle, Running);
-}
-
-#[derive(Component, Debug, Default)]
-#[component(storage = "SparseSet")]
-pub struct Attacking {
-    ticks: u32,
-}
-impl Attacking {
-    const MAX: u32 = 4;
-    const STARTUP: u32 = 0;
-}
-impl GentState for Attacking {}
-
-impl Transitionable<CanAttack> for Attacking {
-    type Removals = (Attacking);
-}
-
-#[derive(Component, Debug, Default)]
-#[component(storage = "SparseSet")]
-pub struct CanAttack;
-impl GentState for CanAttack {}
-
-impl Transitionable<Attacking> for CanAttack {
-    type Removals = (CanAttack);
-}
-
-// Pseudo-States
-// Not quite the same as states, these components enable certain behaviours when attached,
-// and provide storage for that behaviours state
-
-/// If a player attack lands, locks their velocity for the configured number of ticks'
-//Tracks the attack entity which last caused the hirfreeze affect. (this way the same attack
-// doesn't trigger it muyltiple times)
-#[derive(Component, Default, Debug)]
-pub struct HitFreezeTime(u32, Option<Entity>);
-
-#[derive(Component, Default, Debug)]
-pub struct CoyoteTime(f32);
-
-/// Indicates that sliding is tracked for this entity
-#[derive(Component, Default, Debug)]
-pub struct WallSlideTime(f32);
-impl WallSlideTime {
-    /// Player is sliding if f32 value is less then the coyote time
-    /// f32 starts incrementing when the player stops pressing into the wall
-    fn sliding(&self, cfg: &PlayerConfig) -> bool {
-        self.0 <= cfg.max_coyote_time * 2.0
-    }
-}
 
 ///Player behavior systems.
 ///Do stuff here in states and add transitions to other states by pushing
 ///to a TransitionQueue.
-struct PlayerBehaviorPlugin;
+pub struct PlayerBehaviorPlugin;
 
 impl Plugin for PlayerBehaviorPlugin {
     fn build(&self, app: &mut App) {
-        app.insert_resource(PlayerConfig::default());
-        app.add_systems(GameTickUpdate, load_player_config);
         app.add_systems(
             GameTickUpdate,
             (
@@ -397,117 +62,6 @@ impl Plugin for PlayerBehaviorPlugin {
                 .chain(),
         );
     }
-}
-
-#[derive(Resource, Debug, Default)]
-pub struct PlayerConfig {
-    /// The maximum horizontal velocity the player can move at.
-    ///
-    /// (in pixels/second)
-    max_move_vel: f32,
-
-    /// The maximum downward velocity the player can fall at.
-    ///
-    /// (in pixels/second)
-    max_fall_vel: f32,
-
-    /// The initial acceleration applied to the player for the first tick they start moving.
-    ///
-    /// (in pixels/second^2)
-    move_accel_init: f32,
-
-    /// The acceleration applied to the player while they continue moving horizontally.
-    ///
-    /// (in pixels/second^2)
-    move_accel: f32,
-
-    /// How much velocity does the player have at the moment they jump?
-    ///
-    /// (in pixels/second)
-    jump_vel_init: f32,
-
-    /// How fast does the player accelerate downward while holding down the jump button?
-    ///
-    /// (in pixels/second^2)
-    jump_fall_accel: f32,
-
-    /// How fast does the player accelerate downward while in the falling state?
-    /// (ie: after releasing the jump key)
-    ///
-    /// (in pixels/second^2)
-    /// Note: sets the games global_gravity! (affects projectiles and other things that fall)
-    pub fall_accel: f32,
-
-    /// How many seconds does our characters innate hover boots work?
-    max_coyote_time: f32,
-
-    /// Onlly applies in the downward y direction while the player is falling
-    /// and trying to walk into the wall
-    sliding_friction: f32,
-
-    /// How many ticks is the players velocity locked to zero after landing an attack?
-    hitfreeze_ticks: u32,
-}
-
-fn load_player_config(
-    mut ev_asset: EventReader<AssetEvent<DynamicConfig>>,
-    cfgs: Res<Assets<DynamicConfig>>,
-    preloaded: Res<PreloadedAssets>,
-    mut player_config: ResMut<PlayerConfig>,
-    mut commands: Commands,
-    mut initialized_config: Local<bool>,
-) {
-    // convert from asset key string to bevy handle
-    let Some(cfg_handle) = preloaded.get_single_asset::<DynamicConfig>("cfg.player") else {
-        return;
-    };
-    // The reason we do this here instead of in an AssetEvent::Added match arm, is because
-    // the Added match arm fires before preloaded updates with the asset key; as a result
-    // you can't tell what specific DynamicConfig loaded in like that.
-    if !*initialized_config {
-        if let Some(cfg) = cfgs.get(cfg_handle.clone()) {
-            update_player_config(&mut player_config, cfg);
-            println!("init:");
-            dbg!(&player_config);
-        }
-        *initialized_config = true;
-    }
-    for ev in ev_asset.read() {
-        match ev {
-            AssetEvent::Modified { id } => {
-                if let Some(cfg) = cfgs.get(*id) {
-                    if cfg_handle.id() == *id {
-                        println!("before:");
-                        dbg!(&player_config);
-                        update_player_config(&mut player_config, cfg);
-                        println!("after:");
-                        dbg!(&player_config);
-                    }
-                }
-            },
-            _ => {},
-        }
-    }
-}
-
-#[rustfmt::skip]
-fn update_player_config(config: &mut PlayerConfig, cfg: &DynamicConfig) {
-    let mut errors = Vec::new();
-
-    update_field(&mut errors, &cfg.0, "max_move_vel", |val| config.max_move_vel = val);
-    update_field(&mut errors, &cfg.0, "max_fall_vel", |val| config.max_fall_vel = val);
-    update_field(&mut errors, &cfg.0, "move_accel_init", |val| config.move_accel_init = val);
-    update_field(&mut errors, &cfg.0, "move_accel", |val| config.move_accel = val);
-    update_field(&mut errors, &cfg.0, "jump_vel_init", |val| config.jump_vel_init = val);
-    update_field(&mut errors, &cfg.0, "jump_fall_accel", |val| config.jump_fall_accel = val);
-    update_field(&mut errors, &cfg.0, "fall_accel", |val| config.fall_accel = val);
-    update_field(&mut errors, &cfg.0, "max_coyote_time", |val| config.max_coyote_time = val);
-    update_field(&mut errors, &cfg.0, "sliding_friction", |val| config.sliding_friction = val);
-    update_field(&mut errors, &cfg.0, "hitfreeze_ticks", |val| config.hitfreeze_ticks = val as u32);
-
-   for error in errors{
-       warn!("failed to load player cfg value: {}", error);
-   }
 }
 
 fn hitfreeze(
@@ -554,7 +108,7 @@ fn hitfreeze(
     }
 }
 
-fn player_idle(
+pub fn player_idle(
     mut query: Query<
         (
             &ActionState<PlayerAction>,
@@ -578,7 +132,7 @@ fn player_idle(
     }
 }
 
-fn player_move(
+pub fn player_move(
     config: Res<PlayerConfig>,
     mut q_gent: Query<
         (
@@ -634,7 +188,7 @@ fn player_move(
     }
 }
 
-fn set_movement_slots(
+pub fn set_movement_slots(
     mut q_gent: Query<(&LinearVelocity, &Gent), (With<Player>)>,
     mut q_gfx_player: Query<&mut ScriptPlayer<SpriteAnimation>, With<PlayerGfx>>,
 ) {
@@ -667,7 +221,7 @@ fn set_movement_slots(
     }
 }
 
-fn player_run(
+pub fn player_run(
     mut q_gent: Query<
         (
             &ActionState<PlayerAction>,
@@ -693,7 +247,7 @@ fn player_run(
     }
 }
 
-fn player_jump(
+pub fn player_jump(
     mut query: Query<
         (
             &ActionState<PlayerAction>,
@@ -725,7 +279,7 @@ fn player_jump(
     }
 }
 
-fn player_collisions(
+pub fn player_collisions(
     spatial_query: Res<PhysicsWorld>,
     mut q_gent: Query<
         (
@@ -737,7 +291,7 @@ fn player_collisions(
         ),
         (With<Player>),
     >,
-    mut q_enemy: Query<Entity, With<super::enemy::Enemy>>,
+    mut q_enemy: Query<Entity, With<Enemy>>,
     time: Res<GameTime>,
     config: Res<PlayerConfig>,
 ) {
@@ -881,7 +435,7 @@ fn player_collisions(
 /// Needs to be non-zero to avoid getting stuck in the ground.
 const GROUNDED_THRESHOLD: f32 = 1.0;
 
-fn player_grounded(
+pub fn player_grounded(
     spatial_query: Res<PhysicsWorld>,
     mut query: Query<
         (
@@ -948,7 +502,7 @@ fn player_grounded(
     }
 }
 
-fn player_falling(
+pub fn player_falling(
     spatial_query: Res<PhysicsWorld>,
     mut query: Query<
         (
@@ -997,7 +551,7 @@ fn player_falling(
     }
 }
 
-fn player_sliding(
+pub fn player_sliding(
     mut query: Query<(
         &Gent,
         &ActionState<PlayerAction>,
@@ -1027,7 +581,7 @@ fn player_sliding(
     }
 }
 
-fn add_attack(
+pub fn add_attack(
     mut query: Query<
         (
             &mut TransitionQueue,
@@ -1045,7 +599,7 @@ fn add_attack(
     }
 }
 
-fn player_attack(
+pub fn player_attack(
     mut query: Query<
         (
             Entity,
@@ -1079,192 +633,6 @@ fn player_attack(
         attacking.ticks += 1;
         if attacking.ticks == Attacking::MAX * 8 {
             transitions.push(Attacking::new_transition(CanAttack));
-        }
-    }
-}
-
-///play animations here, run after transitions
-struct PlayerAnimationPlugin;
-
-impl Plugin for PlayerAnimationPlugin {
-    fn build(&self, app: &mut App) {
-        app.add_systems(
-            GameTickUpdate,
-            (
-                player_idle_animation,
-                player_falling_animation,
-                player_jumping_animation,
-                player_running_animation,
-                player_attacking_animation,
-                sprite_flip.after(player_attacking_animation),
-            )
-                .in_set(PlayerStateSet::Animation)
-                .after(PlayerStateSet::Transition)
-                .run_if(in_state(AppState::InGame)),
-        );
-    }
-}
-
-fn player_idle_animation(
-    i_query: Query<
-        &Gent,
-        Or<(
-            (Added<Idle>, Without<Attacking>),
-            (With<Idle>, Added<CanAttack>),
-        )>,
-    >,
-    mut gfx_query: Query<&mut ScriptPlayer<SpriteAnimation>, With<PlayerGfx>>,
-) {
-    for gent in i_query.iter() {
-        if let Ok(mut player) = gfx_query.get_mut(gent.e_gfx) {
-            player.play_key("anim.player.Idle")
-        }
-    }
-}
-
-fn player_falling_animation(
-    f_query: Query<
-        (&Gent, Option<&WallSlideTime>),
-        Or<(
-            (With<Falling>, Without<Attacking>),
-            (With<Falling>, Added<CanAttack>),
-        )>,
-    >,
-    mut gfx_query: Query<&mut ScriptPlayer<SpriteAnimation>, With<PlayerGfx>>,
-    config: Res<PlayerConfig>,
-) {
-    for (gent, sliding) in f_query.iter() {
-        if let Ok(mut player) = gfx_query.get_mut(gent.e_gfx) {
-            if let Some(sliding) = sliding {
-                if sliding.sliding(&config) {
-                    if player.current_key().unwrap_or("") != "anim.player.WallSlide" {
-                        player.play_key("anim.player.WallSlide");
-                    }
-                } else {
-                    if player.current_key().unwrap_or("") != "anim.player.Fall" {
-                        player.play_key("anim.player.Fall");
-                    }
-                }
-            } else {
-                if player.current_key().unwrap_or("") != "anim.player.Fall" {
-                    player.play_key("anim.player.Fall");
-                }
-            }
-        }
-    }
-}
-
-fn player_jumping_animation(
-    f_query: Query<
-        &Gent,
-        Or<(
-            (Added<Jumping>, Without<Attacking>),
-            (With<Jumping>, Added<CanAttack>),
-        )>,
-    >,
-    mut gfx_query: Query<&mut ScriptPlayer<SpriteAnimation>, With<PlayerGfx>>,
-) {
-    for gent in f_query.iter() {
-        if let Ok(mut player) = gfx_query.get_mut(gent.e_gfx) {
-            player.play_key("anim.player.Jump")
-        }
-    }
-}
-
-fn player_running_animation(
-    r_query: Query<
-        &Gent,
-        Or<(
-            (Added<Running>, Without<Attacking>),
-            (With<Running>, Added<CanAttack>),
-        )>,
-    >,
-    mut gfx_query: Query<&mut ScriptPlayer<SpriteAnimation>, With<PlayerGfx>>,
-) {
-    for gent in r_query.iter() {
-        if let Ok(mut player) = gfx_query.get_mut(gent.e_gfx) {
-            player.play_key("anim.player.Run")
-        }
-    }
-}
-
-fn player_attacking_animation(
-    r_query: Query<
-        (
-            &Gent,
-            Has<Falling>,
-            Has<Jumping>,
-            Has<Running>,
-            Option<&HitFreezeTime>,
-        ),
-        Added<Attacking>,
-    >,
-    mut gfx_query: Query<&mut ScriptPlayer<SpriteAnimation>, With<PlayerGfx>>,
-    config: Res<PlayerConfig>,
-) {
-    for (gent, is_falling, is_jumping, is_running, hitfrozen) in r_query.iter() {
-        if let Ok(mut player) = gfx_query.get_mut(gent.e_gfx) {
-            let hitfrozen = hitfrozen
-                .map(|f| f.0 < config.hitfreeze_ticks)
-                .unwrap_or(false);
-            if is_falling || is_jumping {
-                player.play_key("anim.player.SwordBasicAir")
-            } else if is_running && !hitfrozen {
-                player.play_key("anim.player.SwordBasicRun")
-            } else {
-                player.play_key("anim.player.SwordBasicIdle")
-            }
-        }
-    }
-    //have to check if first or 2nd attack, play diff anim
-    //also check for up attack?
-}
-
-fn sprite_flip(
-    query: Query<(&Facing, &Gent, Option<&WallSlideTime>)>,
-    mut gfx_query: Query<&mut ScriptPlayer<SpriteAnimation>, With<PlayerGfx>>,
-    mut current_direction: Local<bool>,
-    mut old_direction: Local<bool>,
-    time: Res<GameTime>,
-) {
-    for (facing, gent, wall_slide_time) in query.iter() {
-        if let Ok(mut player) = gfx_query.get_mut(gent.e_gfx) {
-            *old_direction = *current_direction;
-            let mut facing = facing.clone();
-
-            // Have the player face away from the wall if they are attacking while wall sliding
-            let pressed_on_wall = wall_slide_time
-                // checks that player is actually against the wall, rather then it being close
-                // enough time from the player having left the wall to still jump
-                // (ie: not wall_jump_coyote_time)
-                .map(|s| s.0 <= 1.0 / time.hz as f32)
-                .unwrap_or(false);
-            if pressed_on_wall && player.current_key() == Some("anim.player.SwordBasicAir") {
-                facing = match facing {
-                    Facing::Right => Facing::Left,
-                    Facing::Left => Facing::Right,
-                }
-            }
-            match facing {
-                Facing::Right => {
-                    //TODO: toggle facing script action
-                    player.set_slot("DirectionRight", true);
-                    player.set_slot("DirectionLeft", false);
-                    *current_direction = true;
-                },
-                Facing::Left => {
-                    player.set_slot("DirectionRight", false);
-                    player.set_slot("DirectionLeft", true);
-                    *current_direction = false;
-                },
-            }
-
-            // lazy change detection cause I can't be asked to learn proper bevy way lel ~c12
-            if *old_direction != *current_direction {
-                player.set_slot("DirectionChanged", true);
-            } else {
-                player.set_slot("DirectionChanged", false);
-            }
         }
     }
 }


### PR DESCRIPTION
Refactors player.rs into a full module and splits player behaviour and player animation plugins into their own files.
Player.rs was getting a bit monolithic and this is the best time to make the change while fewer player related things are in progress.
It will also make implementing player abilities easier.