### PR TITLE
focus_ability

### DIFF
--- a/game/src/game/player/mod.rs
+++ b/game/src/game/player/mod.rs
@@ -267,6 +267,7 @@ fn setup_player(
                 energy: 0.0,
                 attack_entity: None,
             },
+            Crits::new(2.0),
             TransitionQueue::default(),
         ));
         commands.entity(e_gfx).insert((PlayerGfxBundle {
@@ -427,7 +428,6 @@ impl WallSlideTime {
     }
 }
 
-/// Indicates that sliding is tracked for this entity
 #[derive(Component, Default, Debug)]
 pub struct WhirlAbility {
     active: bool,

--- a/game/src/game/player/mod.rs
+++ b/game/src/game/player/mod.rs
@@ -108,6 +108,7 @@ pub enum PlayerAction {
     Attack,
     Dash,
     Whirl,
+    Focus,
 }
 
 fn debug_player_states(
@@ -249,10 +250,8 @@ fn setup_player(
                     .insert(PlayerAction::Attack, KeyCode::Enter)
                     .insert(PlayerAction::Attack, KeyCode::KeyJ)
                     .insert(PlayerAction::Dash, KeyCode::KeyK)
-                    .insert(
-                        PlayerAction::Whirl,
-                        KeyCode::KeyL,
-                    )
+                    .insert(PlayerAction::Whirl, KeyCode::KeyL)
+                    .insert(PlayerAction::Focus, KeyCode::KeyI)
                     .build(),
             },
             Falling,
@@ -268,6 +267,7 @@ fn setup_player(
                 attack_entity: None,
             },
             Crits::new(2.0),
+            FocusAbility::default(),
             TransitionQueue::default(),
         ));
         commands.entity(e_gfx).insert((PlayerGfxBundle {
@@ -434,6 +434,31 @@ pub struct WhirlAbility {
     active_ticks: u32,
     energy: f32,
     attack_entity: Option<Entity>,
+}
+
+#[derive(Component, Debug)]
+pub struct FocusAbility {
+    /// Will the next attack apply double damage?
+    pub(crate) state: FocusState,
+    /// Once this reaches 10, ability can activate again.
+    pub(crate) recharge: f32,
+}
+
+impl Default for FocusAbility {
+    fn default() -> Self {
+        Self {
+            state: Default::default(),
+            recharge: 10.0,
+        }
+    }
+}
+
+#[derive(Default, Debug, PartialEq)]
+pub enum FocusState {
+    Active,
+    Applied,
+    #[default]
+    InActive,
 }
 
 #[derive(Resource, Debug, Default)]

--- a/game/src/graphics/dmg_numbers.rs
+++ b/game/src/graphics/dmg_numbers.rs
@@ -81,7 +81,11 @@ fn instance(
                             TextStyle {
                                 font: asset_server.load("font/Tektur-Regular.ttf"),
                                 font_size: 42.0,
-                                color: Color::WHITE,
+                                color: if attack_info.crit {
+                                    Color::YELLOW * 1.1
+                                } else {
+                                    Color::WHITE
+                                },
                             },
                         )
                         .with_style(Style {


### PR DESCRIPTION
Implements critical strikes, and the new Focus ability, which will double your damage, but has a 10 second cooldown.
If focus is active during a critical strike, it can be re-activated with no cooldown.