### PR TITLE
Fix `just_pressed` in `GameTickUpdate`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,7 +62,9 @@ bevy-inspector-egui = "0.24"
 # This specific rev was working main on may 28th.
 # needed for moveble forcefields not availible in 0.10
 # (also has some wgsl fixes)
-bevy_hanabi = { git = "https://github.com/djeedai/bevy_hanabi", rev = "cabb3cb", default-features = false, features = ["2d"] }
+bevy_hanabi = { git = "https://github.com/djeedai/bevy_hanabi", rev = "cabb3cb", default-features = false, features = [
+  "2d",
+] }
 
 
 [dependencies.serde]
@@ -119,7 +121,8 @@ features = ["iyes_cli"]
 git = "https://github.com/TheSeekerGame/sickle_ui.git"
 
 [dependencies.leafwing-input-manager]
-version = "0.13"
+git = "https://github.com/TheSeekerGame/leafwing-input-manager"
+branch = "fixed_update_0.13"
 
 [dependencies.rapier2d]
 version = "0.18"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,9 +62,7 @@ bevy-inspector-egui = "0.24"
 # This specific rev was working main on may 28th.
 # needed for moveble forcefields not availible in 0.10
 # (also has some wgsl fixes)
-bevy_hanabi = { git = "https://github.com/djeedai/bevy_hanabi", rev = "cabb3cb", default-features = false, features = [
-  "2d",
-] }
+bevy_hanabi = { git = "https://github.com/djeedai/bevy_hanabi", rev = "cabb3cb", default-features = false, features = ["2d"] }
 
 
 [dependencies.serde]

--- a/engine/src/input.rs
+++ b/engine/src/input.rs
@@ -93,7 +93,7 @@ impl<A: Actionlike + TypePath> Plugin for InputManagerPlugin<A> {
             InputManagerSystem::Update.after(InputSystem),
         );
 
-        // GameTickUpdate just_pressed
+        // GameTickUpdate just_pressed state fixes
         app.add_systems(
             Update,
             (

--- a/engine/src/input.rs
+++ b/engine/src/input.rs
@@ -93,12 +93,12 @@ impl<A: Actionlike + TypePath> Plugin for InputManagerPlugin<A> {
             InputManagerSystem::Update.after(InputSystem),
         );
 
-        // FixedMain schedule
+        // GameTickUpdate just_pressed
         app.add_systems(
             Update,
             (
                 swap_to_fixed_update::<A>,
-                // we want to update the ActionState only once, even if the FixedMain schedule runs multiple times
+                // we want to update the ActionState only once, even if the GameTickUpdate schedule runs multiple times
                 update_action_state::<A>,
             )
                 .chain()
@@ -110,6 +110,7 @@ impl<A: Actionlike + TypePath> Plugin for InputManagerPlugin<A> {
             release_on_input_map_removed::<A>,
         );
         app.add_systems(
+            // this needs to run between runs of GameTickUpdate
             GameTickPost,
             tick_action_state::<A>
                 .in_set(InputManagerSystem::Tick)

--- a/engine/src/input.rs
+++ b/engine/src/input.rs
@@ -1,5 +1,5 @@
-//! reimplementation of the leafwing_input_manager plugin
-
+/// reimplementation of the leafwing_input_manager plugin to allow for input state update systems
+/// in our custom fixed timestep
 use core::hash::Hash;
 use core::marker::PhantomData;
 use leafwing_input_manager::action_state::{ActionData, ActionState};

--- a/engine/src/input.rs
+++ b/engine/src/input.rs
@@ -11,22 +11,17 @@ use leafwing_input_manager::buttonlike::{MouseMotionDirection, MouseWheelDirecti
 use leafwing_input_manager::clashing_inputs::ClashStrategy;
 use leafwing_input_manager::input_map::InputMap;
 use leafwing_input_manager::input_processing::*;
-#[cfg(feature = "timing")]
-use leafwing_input_manager::timing::Timing;
 use leafwing_input_manager::user_input::{InputKind, Modifier, UserInput};
 use leafwing_input_manager::Actionlike;
 use std::fmt::Debug;
 
-use bevy::app::{App, Plugin, RunFixedMainLoop, Update};
+use bevy::app::{App, Plugin, Update};
 use bevy::ecs::prelude::*;
 use bevy::input::{ButtonState, InputSystem};
-use bevy::prelude::{FixedPostUpdate, PostUpdate, PreUpdate};
+use bevy::prelude::{PostUpdate, PreUpdate};
 use bevy::reflect::TypePath;
-use bevy::time::run_fixed_main_schedule;
-#[cfg(feature = "ui")]
-use bevy::ui::UiSystem;
 
-use crate::{time::GameTickPost, GameTickSet, GameTickUpdate};
+use crate::{time::GameTickPost, GameTickSet};
 
 /// A [`Plugin`] that collects [`ButtonInput`](bevy::input::ButtonInput) from disparate sources,
 /// producing an [`ActionState`] that can be conveniently checked
@@ -100,7 +95,7 @@ impl<A: Actionlike + TypePath> Plugin for InputManagerPlugin<A> {
 
         // FixedMain schedule
         app.add_systems(
-            RunFixedMainLoop,
+            Update,
             (
                 swap_to_fixed_update::<A>,
                 // we want to update the ActionState only once, even if the FixedMain schedule runs multiple times
@@ -108,24 +103,20 @@ impl<A: Actionlike + TypePath> Plugin for InputManagerPlugin<A> {
             )
                 .chain()
                 .in_set(GameTickSet::Pre),
-            // .before(run_fixed_main_schedule),
         );
 
         app.add_systems(
             GameTickPost,
-            // FixedPostUpdate,
             release_on_input_map_removed::<A>,
         );
         app.add_systems(
             GameTickPost,
-            // FixedPostUpdate,
             tick_action_state::<A>
                 .in_set(InputManagerSystem::Tick)
                 .before(InputManagerSystem::Update),
         );
         app.add_systems(
             Update,
-            // RunFixedMainLoop,
             swap_to_update::<A>.in_set(GameTickSet::Post),
         );
 

--- a/engine/src/input.rs
+++ b/engine/src/input.rs
@@ -1,0 +1,184 @@
+//! reimplementation of the leafwing_input_manager plugin
+
+use core::hash::Hash;
+use core::marker::PhantomData;
+use leafwing_input_manager::action_state::{ActionData, ActionState};
+use leafwing_input_manager::axislike::{
+    AxisType, DualAxis, DualAxisData, MouseMotionAxisType, MouseWheelAxisType, SingleAxis,
+    VirtualAxis, VirtualDPad,
+};
+use leafwing_input_manager::buttonlike::{MouseMotionDirection, MouseWheelDirection};
+use leafwing_input_manager::clashing_inputs::ClashStrategy;
+use leafwing_input_manager::input_map::InputMap;
+use leafwing_input_manager::input_processing::*;
+#[cfg(feature = "timing")]
+use leafwing_input_manager::timing::Timing;
+use leafwing_input_manager::user_input::{InputKind, Modifier, UserInput};
+use leafwing_input_manager::Actionlike;
+use std::fmt::Debug;
+
+use bevy::app::{App, Plugin, RunFixedMainLoop, Update};
+use bevy::ecs::prelude::*;
+use bevy::input::{ButtonState, InputSystem};
+use bevy::prelude::{FixedPostUpdate, PostUpdate, PreUpdate};
+use bevy::reflect::TypePath;
+use bevy::time::run_fixed_main_schedule;
+#[cfg(feature = "ui")]
+use bevy::ui::UiSystem;
+
+use crate::{time::GameTickPost, GameTickSet, GameTickUpdate};
+
+/// A [`Plugin`] that collects [`ButtonInput`](bevy::input::ButtonInput) from disparate sources,
+/// producing an [`ActionState`] that can be conveniently checked
+///
+/// This plugin needs to be passed in an [`Actionlike`] enum type that you've created for your game.
+/// Each variant represents a "virtual button" whose state is stored in an [`ActionState`] struct.
+///
+/// Each [`InputManagerBundle`](crate::InputManagerBundle) contains:
+///  - an [`InputMap`] component, which stores an entity-specific mapping between the assorted input streams and an internal representation of "actions"
+///  - an [`ActionState`] component, which stores the current input state for that entity in a source-agnostic fashion
+///
+/// If you have more than one distinct type of action (e.g., menu actions, camera actions, and player actions),
+/// consider creating multiple `Actionlike` enums
+/// and adding a copy of this plugin for each `Actionlike` type.
+///
+/// All actions can be dynamically enabled or disabled by calling the relevant methods on
+/// `ActionState<A>`. This can be useful when working with states to pause the game, navigate
+/// menus, and so on.
+///
+/// ## Systems
+///
+/// **WARNING:** These systems run during [`PreUpdate`].
+/// If you have systems that care about inputs and actions that also run during this stage,
+/// you must define an ordering between your systems or behavior will be very erratic.
+/// The stable system sets for these systems are available under [`InputManagerSystem`] enum.
+///
+/// Complete list:
+///
+/// - [`tick_action_state`](crate::systems::tick_action_state), which resets the `pressed` and `just_pressed` fields of the [`ActionState`] each frame
+/// - [`update_action_state`](crate::systems::update_action_state), which collects [`ButtonInput`](bevy::input::ButtonInput) resources to update the [`ActionState`]
+/// - [`update_action_state_from_interaction`](crate::systems::update_action_state_from_interaction), for triggering actions from buttons
+///    - powers the [`ActionStateDriver`](crate::action_driver::ActionStateDriver) component based on an [`Interaction`](bevy::ui::Interaction) component
+pub struct InputManagerPlugin<A: Actionlike> {
+    _phantom: PhantomData<A>,
+}
+
+// Deriving default induces an undesired bound on the generic
+impl<A: Actionlike> Default for InputManagerPlugin<A> {
+    fn default() -> Self {
+        Self {
+            _phantom: PhantomData,
+        }
+    }
+}
+
+impl<A: Actionlike + TypePath> Plugin for InputManagerPlugin<A> {
+    fn build(&self, app: &mut App) {
+        use leafwing_input_manager::systems::*;
+
+        // Main schedule
+        app.add_systems(
+            PreUpdate,
+            tick_action_state::<A>
+                .in_set(InputManagerSystem::Tick)
+                .before(InputManagerSystem::Update),
+        )
+        .add_systems(
+            PostUpdate,
+            release_on_input_map_removed::<A>,
+        );
+
+        app.add_systems(
+            PreUpdate,
+            update_action_state::<A>.in_set(InputManagerSystem::Update),
+        );
+
+        app.configure_sets(
+            PreUpdate,
+            InputManagerSystem::Update.after(InputSystem),
+        );
+
+        // FixedMain schedule
+        app.add_systems(
+            RunFixedMainLoop,
+            (
+                swap_to_fixed_update::<A>,
+                // we want to update the ActionState only once, even if the FixedMain schedule runs multiple times
+                update_action_state::<A>,
+            )
+                .chain()
+                .in_set(GameTickSet::Pre),
+            // .before(run_fixed_main_schedule),
+        );
+
+        app.add_systems(
+            GameTickPost,
+            // FixedPostUpdate,
+            release_on_input_map_removed::<A>,
+        );
+        app.add_systems(
+            GameTickPost,
+            // FixedPostUpdate,
+            tick_action_state::<A>
+                .in_set(InputManagerSystem::Tick)
+                .before(InputManagerSystem::Update),
+        );
+        app.add_systems(
+            Update,
+            // RunFixedMainLoop,
+            swap_to_update::<A>.in_set(GameTickSet::Post),
+        );
+
+        app.register_type::<ActionState<A>>()
+            .register_type::<InputMap<A>>()
+            .register_type::<UserInput>()
+            .register_type::<InputKind>()
+            .register_type::<ActionData>()
+            .register_type::<Modifier>()
+            .register_type::<ActionState<A>>()
+            .register_type::<VirtualDPad>()
+            .register_type::<VirtualAxis>()
+            .register_type::<SingleAxis>()
+            .register_type::<DualAxis>()
+            .register_type::<AxisType>()
+            .register_type::<MouseWheelAxisType>()
+            .register_type::<MouseMotionAxisType>()
+            .register_type::<DualAxisData>()
+            .register_type::<ButtonState>()
+            .register_type::<MouseWheelDirection>()
+            .register_type::<MouseMotionDirection>()
+            // Processors
+            .register_type::<AxisProcessor>()
+            .register_type::<AxisBounds>()
+            .register_type::<AxisExclusion>()
+            .register_type::<AxisDeadZone>()
+            .register_type::<DualAxisProcessor>()
+            .register_type::<DualAxisInverted>()
+            .register_type::<DualAxisSensitivity>()
+            .register_type::<DualAxisBounds>()
+            .register_type::<DualAxisExclusion>()
+            .register_type::<DualAxisDeadZone>()
+            .register_type::<CircleBounds>()
+            .register_type::<CircleExclusion>()
+            .register_type::<CircleDeadZone>()
+            // Resources
+            .init_resource::<ClashStrategy>();
+    }
+}
+
+/// [`SystemSet`]s for the [`crate::systems`] used by this crate
+///
+/// `Reset` must occur before `Update`
+#[derive(SystemSet, Clone, Hash, Debug, PartialEq, Eq)]
+pub enum InputManagerSystem {
+    /// Advances action timers.
+    ///
+    /// Cleans up the state of the input manager, clearing `just_pressed` and `just_released`
+    Tick,
+    /// Collects input data to update the [`ActionState`]
+    Update,
+    /// Manually control the [`ActionState`]
+    ///
+    /// Must run after [`InputManagerSystem::Update`] or the action state will be overridden
+    ManualControl,
+}

--- a/engine/src/lib.rs
+++ b/engine/src/lib.rs
@@ -36,6 +36,7 @@ pub mod ballistics_math;
 pub mod condition;
 pub mod data;
 pub mod gent;
+pub mod input;
 pub mod physics;
 pub mod script;
 pub mod time;

--- a/engine/src/time.rs
+++ b/engine/src/time.rs
@@ -6,7 +6,9 @@ pub struct GameTimePlugin;
 
 impl Plugin for GameTimePlugin {
     fn build(&self, app: &mut App) {
+        app.init_schedule(GameTickPre);
         app.init_schedule(GameTickUpdate);
+        app.init_schedule(GameTickPost);
         app.init_resource::<GameTime>();
         app.add_systems(
             Update,
@@ -67,6 +69,12 @@ fn minimal_event_update_system<T: Event>(mut events: ResMut<Events<T>>) {
 /// Our alternative to `FixedUpdate`
 #[derive(ScheduleLabel, Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct GameTickUpdate;
+
+#[derive(ScheduleLabel, Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct GameTickPre;
+
+#[derive(ScheduleLabel, Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct GameTickPost;
 
 #[derive(Resource, Debug)]
 pub struct GameTime {
@@ -164,7 +172,9 @@ pub fn run_gametickupdate_schedule(world: &mut World) {
         if gametime.tick >= gametime.total_ticks {
             break;
         }
+        world.run_schedule(GameTickPre);
         world.run_schedule(GameTickUpdate);
+        world.run_schedule(GameTickPost);
         world.resource_mut::<GameTime>().tick += 1;
     }
 }

--- a/engine/src/time.rs
+++ b/engine/src/time.rs
@@ -69,8 +69,8 @@ fn minimal_event_update_system<T: Event>(mut events: ResMut<Events<T>>) {
 #[derive(ScheduleLabel, Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct GameTickUpdate;
 
-/// Run after `GameTickUpdate`, matching run
-/// used for updating input state after each GameTickUpdate run before next GameTickUpdate
+/// Run after `GameTickUpdate`
+/// used for running systems which update input state between GameTickUpdate runs
 #[derive(ScheduleLabel, Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct GameTickPost;
 

--- a/engine/src/time.rs
+++ b/engine/src/time.rs
@@ -6,7 +6,6 @@ pub struct GameTimePlugin;
 
 impl Plugin for GameTimePlugin {
     fn build(&self, app: &mut App) {
-        app.init_schedule(GameTickPre);
         app.init_schedule(GameTickUpdate);
         app.init_schedule(GameTickPost);
         app.init_resource::<GameTime>();
@@ -70,9 +69,8 @@ fn minimal_event_update_system<T: Event>(mut events: ResMut<Events<T>>) {
 #[derive(ScheduleLabel, Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct GameTickUpdate;
 
-#[derive(ScheduleLabel, Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub struct GameTickPre;
-
+/// Run after `GameTickUpdate`, matching run
+/// used for updating input state after each GameTickUpdate run before next GameTickUpdate
 #[derive(ScheduleLabel, Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct GameTickPost;
 

--- a/engine/src/time.rs
+++ b/engine/src/time.rs
@@ -170,7 +170,6 @@ pub fn run_gametickupdate_schedule(world: &mut World) {
         if gametime.tick >= gametime.total_ticks {
             break;
         }
-        world.run_schedule(GameTickPre);
         world.run_schedule(GameTickUpdate);
         world.run_schedule(GameTickPost);
         world.resource_mut::<GameTime>().tick += 1;

--- a/game/src/game/player/mod.rs
+++ b/game/src/game/player/mod.rs
@@ -3,7 +3,11 @@ mod player_behaviour;
 
 use bevy::transform::TransformSystem::TransformPropagate;
 use leafwing_input_manager::axislike::VirtualAxis;
-use leafwing_input_manager::prelude::*;
+use theseeker_engine::input::InputManagerPlugin;
+// use leafwing_input_manager::prelude::*;
+use leafwing_input_manager::{
+    action_state::ActionState, input_map::InputMap, Actionlike, InputManagerBundle,
+};
 use player_anim::PlayerAnimationPlugin;
 use player_behaviour::PlayerBehaviorPlugin;
 use rapier2d::geometry::{Group, InteractionGroups};
@@ -236,23 +240,22 @@ fn setup_player(
             InputManagerBundle::<PlayerAction> {
                 action_state: ActionState::default(),
                 input_map: InputMap::default()
-                    .insert(PlayerAction::Jump, KeyCode::Space)
-                    .insert(PlayerAction::Jump, KeyCode::KeyW)
-                    .insert(PlayerAction::Jump, KeyCode::ArrowUp)
-                    .insert(
+                    .with(PlayerAction::Jump, KeyCode::Space)
+                    .with(PlayerAction::Jump, KeyCode::KeyW)
+                    .with(PlayerAction::Jump, KeyCode::ArrowUp)
+                    .with(
                         PlayerAction::Move,
                         VirtualAxis::from_keys(KeyCode::KeyA, KeyCode::KeyD),
                     )
-                    .insert(
+                    .with(
                         PlayerAction::Move,
                         VirtualAxis::from_keys(KeyCode::ArrowLeft, KeyCode::ArrowRight),
                     )
-                    .insert(PlayerAction::Attack, KeyCode::Enter)
-                    .insert(PlayerAction::Attack, KeyCode::KeyJ)
-                    .insert(PlayerAction::Dash, KeyCode::KeyK)
-                    .insert(PlayerAction::Whirl, KeyCode::KeyL)
-                    .insert(PlayerAction::Focus, KeyCode::KeyI)
-                    .build(),
+                    .with(PlayerAction::Attack, KeyCode::Enter)
+                    .with(PlayerAction::Attack, KeyCode::KeyJ)
+                    .with(PlayerAction::Dash, KeyCode::KeyK)
+                    .with(PlayerAction::Whirl, KeyCode::KeyL)
+                    .with(PlayerAction::Focus, KeyCode::KeyI),
             },
             Falling,
             CanDash {

--- a/game/src/game/player/mod.rs
+++ b/game/src/game/player/mod.rs
@@ -1,10 +1,6 @@
 mod player_anim;
 mod player_behaviour;
-
-use bevy::transform::TransformSystem::TransformPropagate;
 use leafwing_input_manager::axislike::VirtualAxis;
-use theseeker_engine::input::InputManagerPlugin;
-// use leafwing_input_manager::prelude::*;
 use leafwing_input_manager::{
     action_state::ActionState, input_map::InputMap, Actionlike, InputManagerBundle,
 };
@@ -16,6 +12,7 @@ use theseeker_engine::animation::SpriteAnimationBundle;
 use theseeker_engine::assets::animation::SpriteAnimation;
 use theseeker_engine::assets::config::{update_field, DynamicConfig};
 use theseeker_engine::gent::{Gent, GentPhysicsBundle, TransformGfxFromGent};
+use theseeker_engine::input::InputManagerPlugin;
 use theseeker_engine::physics::{
     into_vec2, AnimationCollider, Collider, LinearVelocity, PhysicsWorld, ShapeCaster, ENEMY,
     GROUND, PLAYER, PLAYER_ATTACK,


### PR DESCRIPTION
This pr adapts the pr from LWIM which fixes the behavior of `just_pressed` and `just_released` in `FixedUpdate` https://github.com/Leafwing-Studios/leafwing-input-manager/pull/522  to work with our `GameTickUpdate` schedule. It relies on a branch of LWIM with an older version of the fix applied to the bevy 0.13 compatible branch, and re-implements the `InputManagerPlugin` to add the pressed state updating systems to the correct schedules and sets when building.