### PR TITLE
immediately follow attack on new press

### DIFF
--- a/game/src/game/gentstate.rs
+++ b/game/src/game/gentstate.rs
@@ -32,10 +32,6 @@ pub trait Transitionable<T: GentState> {
     }
 }
 
-//Box<dyn Transition>
-//imp Transition
-//apply
-
 //make not component, make field of state machine
 #[derive(Component, Deref, DerefMut, Default)]
 pub struct TransitionQueue(Vec<Box<dyn FnOnce(Entity, &mut Commands) + Send + Sync>>);

--- a/game/src/game/gentstate.rs
+++ b/game/src/game/gentstate.rs
@@ -32,6 +32,10 @@ pub trait Transitionable<T: GentState> {
     }
 }
 
+//Box<dyn Transition>
+//imp Transition
+//apply
+
 //make not component, make field of state machine
 #[derive(Component, Deref, DerefMut, Default)]
 pub struct TransitionQueue(Vec<Box<dyn FnOnce(Entity, &mut Commands) + Send + Sync>>);

--- a/game/src/game/player/mod.rs
+++ b/game/src/game/player/mod.rs
@@ -359,6 +359,7 @@ impl Transitionable<Falling> for Grounded {
 #[component(storage = "SparseSet")]
 pub struct Attacking {
     pub ticks: u32,
+    followup: bool,
 }
 impl Attacking {
     pub const MAX: u32 = 4;
@@ -371,7 +372,9 @@ impl Transitionable<CanAttack> for Attacking {
 
 #[derive(Component, Debug, Default)]
 #[component(storage = "SparseSet")]
-pub struct CanAttack;
+pub struct CanAttack {
+    pub immediate: bool,
+}
 impl GentState for CanAttack {}
 
 impl Transitionable<Attacking> for CanAttack {


### PR DESCRIPTION
Attack now doesn't continuously trigger if held down, but if an attack input is pressed during the later half of the animation another attack will be queued up immediately on transition.