### PR TITLE
Double Jump Implementation

### DIFF
--- a/assets/player.cfg.toml
+++ b/assets/player.cfg.toml
@@ -65,3 +65,9 @@ whirl_regen = 0.7
 
 # How much max health the player has
 max_health = 150.0
+
+# Pushback velocity on wall jumps
+wall_pushback = 50.0
+
+# Ticks for wall pushback velocity; determines how long movement is locked for 
+wall_pushback_ticks = 5.0

--- a/game/src/game/player/mod.rs
+++ b/game/src/game/player/mod.rs
@@ -264,6 +264,7 @@ fn setup_player(
             },
             WallSlideTime(f32::MAX),
             HitFreezeTime(u32::MAX, None),
+            JumpCount(0),
             WhirlAbility {
                 active: false,
                 active_ticks: 0,
@@ -460,6 +461,9 @@ pub struct HitFreezeTime(u32, Option<Entity>);
 
 #[derive(Component, Default, Debug)]
 pub struct CoyoteTime(f32);
+
+#[derive(Component, Default, Debug)]
+pub struct JumpCount(u8);
 
 /// Indicates that sliding is tracked for this entity
 #[derive(Component, Default, Debug)]

--- a/game/src/game/player/mod.rs
+++ b/game/src/game/player/mod.rs
@@ -465,6 +465,27 @@ pub struct CoyoteTime(f32);
 #[derive(Component, Default, Debug)]
 pub struct JumpCount(u8);
 
+/// Pushback applied to the player for movement effects. Velocity is applied once and then blocks horizontal player movement.
+#[derive(Component, Default, Debug)]
+pub struct PlayerPushback {
+    pub ticks: u32,
+    pub max_ticks: u32,
+    pub x_direction: f32,
+//    pub y_direction: f32,
+    pub strength: Vec2,
+}
+
+impl PlayerPushback {
+    pub fn new(x_direction: f32, strength: Vec2, max_ticks: u32) -> Self {
+        Self {
+            ticks: 0,
+            max_ticks,
+            x_direction,
+            strength,
+        }
+    }
+}
+
 /// Indicates that sliding is tracked for this entity
 #[derive(Component, Default, Debug)]
 pub struct WallSlideTime(f32);
@@ -473,6 +494,9 @@ impl WallSlideTime {
     /// f32 starts incrementing when the player stops pressing into the wall
     fn sliding(&self, cfg: &PlayerConfig) -> bool {
         self.0 <= cfg.max_coyote_time * 2.0
+    }
+    fn strict_sliding(&self, cfg: &PlayerConfig) -> bool {
+        self.0 <= cfg.max_coyote_time * 1.0
     }
 }
 
@@ -558,6 +582,12 @@ pub struct PlayerConfig {
 
     /// How much max health the player has
     pub max_health: u32,
+
+    /// Pushback velocity on wall jumps
+    wall_pushback: f32,
+
+    /// Ticks for wall pushback velocity; determines how long movement is locked for 
+    wall_pushback_ticks :u32,
 }
 
 fn load_player_config(
@@ -624,8 +654,10 @@ fn update_player_config(config: &mut PlayerConfig, cfg: &DynamicConfig) {
     update_field(&mut errors, &cfg.0, "whirl_cost", |val| config.whirl_cost = val);
     update_field(&mut errors, &cfg.0, "whirl_regen", |val| config.whirl_regen = val);
     update_field(&mut errors, &cfg.0, "max_health", |val| config.max_health = val as u32);
-
-   for error in errors{
+    update_field(&mut errors, &cfg.0, "wall_pushback", |val| config.wall_pushback = val);
+    update_field(&mut errors, &cfg.0, "wall_pushback_ticks", |val| config.wall_pushback_ticks = val as u32);
+    
+    for error in errors{
        warn!("failed to load player cfg value: {}", error);
    }
 }


### PR DESCRIPTION
Technical Summary:

- Added JumpCount(u8) Component for tracking available jumps. Added to player on setup_player.
- JumpCount is reset in player_grounded, player_sliding.
- when Jumping in player_falling, checks for JumpCount field > 0; if valid jumps and decrements by 1

Gameplay Mechanics Related: 
The Air Jump functions the same as the normal grounded jump, with controlled jump height - so unlike in Hollow Knight, where the double jump gives a consistent upwards burst.
Typical platformer mechanic is maintained of only having a single jump when walking of a platform, with respect for coyote time of course :)
The same pertains to jumping when wall-sliding, however jumping from the wall counts as your double jump - since the state transitions into Falling(?). Walking off of a wall allows you to jump in the air as one would expect.

However, this issue with jumping is not too important, as the wall-jump code will need to be modified in the "Wall Jump Pushback" implementation anyways.