### PR TITLE
Chill Effect Implementation

### DIFF
--- a/game/src/game/enemy.rs
+++ b/game/src/game/enemy.rs
@@ -15,7 +15,7 @@ use theseeker_engine::script::ScriptPlayer;
 use theseeker_engine::{animation::SpriteAnimationBundle, physics::ENEMY_INSIDE};
 use theseeker_engine::{assets::animation::SpriteAnimation, physics::ENEMY_HURT};
 
-use super::player::{Player, PlayerConfig, Stealthing};
+use super::player::{Player, PlayerConfig, StatusModifier, Stealthing};
 use crate::game::attack::arc_attack::Projectile;
 use crate::game::attack::particles::ArcParticleEffectHandle;
 use crate::game::attack::*;
@@ -904,7 +904,8 @@ fn ranged_attack(
             // spawn in the new projectile:
             commands
                 .spawn((
-                    Attack::new(1000, entity),
+                    Attack::new(1000, entity)
+                        .set_stat_mod(StatusModifier::basic_ice_spider()),
                     final_solution,
                     Collider::cuboid(
                         5.,


### PR DESCRIPTION
Implementation for "Chill Effect" with a general extendable system for Status Modifiers on the player.
Currently only allows for a single type of active status modifier; new applications replace the old one.

PlayerStats added; copies data from PlayerConfig and adds StatusModifiers.
Changed player_move code to read from PlayerStats instead - any additional "status impairable stats" will need to do the same.
