### PR TITLE
Dash After-Image implemented

### DIFF
--- a/game/src/game/player/player_behaviour.rs
+++ b/game/src/game/player/player_behaviour.rs
@@ -29,8 +29,8 @@ use theseeker_engine::prelude::{GameTickUpdate, GameTime};
 use theseeker_engine::script::ScriptPlayer;
 
 use super::{
-    player_new_stats_mod, CanStealth, JumpCount, Knockback, PlayerPushback, PlayerStats, StatType,
-    Stealthing,
+    dash_icon_fx, player_dash_fx, player_new_stats_mod, CanStealth, DashIcon, JumpCount, Knockback,
+    PlayerPushback, PlayerStats, StatType, Stealthing,
 };
 
 ///Player behavior systems.
@@ -56,6 +56,12 @@ impl Plugin for PlayerBehaviorPlugin {
                     player_run.run_if(any_with_component::<Running>),
                     player_jump.run_if(any_with_component::<Jumping>),
                     player_dash.run_if(any_with_component::<Dashing>),
+                    player_dash_fx
+                        .after(player_dash)
+                        .run_if(any_with_component::<Dashing>),
+                    dash_icon_fx
+                        .after(player_dash_fx)
+                        .run_if(any_with_component::<DashIcon>),
                     player_grounded.run_if(any_with_component::<Grounded>),
                     player_falling.run_if(any_with_component::<Falling>),
                     player_pushback.run_if(any_with_component::<PlayerPushback>),
@@ -1078,4 +1084,3 @@ fn player_pushback(
         }
     }
 }
-


### PR DESCRIPTION
Implementation for an After Image while Dashing.
The "Dash Icon" is spawned at the player position every frame while dashing, which gives good coverage. Depending on changes to the tick-rate, a more nuanced effect with interpolation may be preferred.
Icons fade out quickly. also works with Stealth; The Alpha of the Icon image is set lower if stealthed, giving a good effect imo.

Code is currently in player_behaviour.rs and player/mod.rs so it's close to the dash code; 
depending on further features (like hit-sparks), refactoring it to a file named something like player_vfx.rs may make for a cleaner code structure.
