### PR TITLE
Animation/Scripting Improvements

### DIFF
--- a/doc/src/tech/anim-ref.md
+++ b/doc/src/tech/anim-ref.md
@@ -474,7 +474,7 @@ In dev builds, the game might print warnings to the log/console.
 
 <details>
   <summary>
-  <code>if_frame_lt</code>/<code>if_frame_le</code>/<code>if_frame_gt</code>/<code>if_frame_ge</code>
+  <code>if_frame_lt</code>/<code>if_frame_le</code>/<code>if_frame_gt</code>/<code>if_frame_ge</code>/<code>if_frame_is</code>/<code>if_frame_is_not</code>
   </summary>
 
 Example:
@@ -494,16 +494,30 @@ action = "..."
 run_every_n_ticks = "5+1"
 if_frame_lt = "my_bookmark"
 action = "..."
+
+# Do something as soon as the "attack" slot is enabled,
+# but only if we are currently displaying frame 6
+[[script]]
+run_on_slot_enable = "attack"
+if_frame_is = 6
+action = "..."
+
+# Do something every 3 ticks, but only if we are not currently
+# displaying one of the special magic frames
+[[script]]
+run_every_n_ticks = "3"
+if_frame_is_not = [ 3, 7, 9 ]
+action = "..."
 ```
 
 Only run the action if the current frame index is:
 
- - less than (lt)
- - less than or equal to (le)
- - greater than (gt)
- - greater than or equal to (ge)
-
-the specified value.
+ - less than a given value (`lt`)
+ - less than or equal to a given value (`le`)
+ - greater than a given value (`gt`)
+ - greater than or equal to a given value (`ge`)
+ - equal to any of the specified values (`is`)
+ - not equal to any of the specified values (`is_not`)
 
 It can be specified as either a number or a frame bookmark. If specified
 as a number, it will be relative to `frame_bookmark`, if set.
@@ -512,32 +526,52 @@ as a number, it will be relative to `frame_bookmark`, if set.
 
 <details>
   <summary>
-  <code>if_frame_is</code>
+  <code>if_oldanim_frame_lt</code>/<code>if_oldanim_frame_le</code>/<code>if_oldanim_frame_gt</code>/<code>if_oldanim_frame_ge</code>/<code>if_oldanim_frame_was</code>/<code>if_oldanim_frame_was_not</code>
   </summary>
 
 Example:
 
 ```toml
-# Do something as soon as the "attack" slot is enabled,
-# but only if we are currently displaying frame 6
+# Do something when the animation starts,
+# but only if the previouly-playing animation
+# was "anim.Player.Attack"
+# and it had not yet reached frame 7
 [[script]]
-run_on_slot_enable = "attack"
-if_frame_is = 6
+run_on_playback_control = "Start"
+if_previous_script_key = "anim.Player.Attack"
+if_oldanim_frame_lt = 7
 action = "..."
 
-# Do something every 3 ticks, but only if we are currently
-# displaying one of the special magic frames
+# Do something on tick 3,
+# but only if the previously-playing animation
+# was "anim.Player.Run"
+# and it was on frame 15
+# (when the current animation was started)
 [[script]]
-run_every_n_ticks = "3"
-if_frame_is = [ 3, 7, 9 ]
+run_at_tick = 3
+if_previous_script_key = "anim.Player.Run"
+if_oldanim_frame_was = 15
 action = "..."
 ```
 
-Only run the action if the current frame index is equal to any of
-the specified values.
+These parameters let you perform actions depending on where the
+previously-playing animation (if any) left off. This allows you to implement
+special handling for specific transitions between animations.
 
-The values can be specified as either a number or a frame bookmark. If
-specified as a number, it will be relative to `frame_bookmark`, if set.
+These parameters should be used together with `if_previous_script_key`.
+
+Only run the action if the frame index of the previously-playing animation
+(at the time of switching to the current animation) was:
+
+ - less than a given value (`lt`)
+ - less than or equal to a given value (`le`)
+ - greater than a given value (`gt`)
+ - greater than or equal to a given value (`ge`)
+ - equal to any of the specified values (`was`)
+ - not equal to any of the specified values (`was_not`)
+
+The provided values must be literal numbers. Since they refer to a different
+animation asset, bookmarks are not taken into account.
 
 </details>
 

--- a/doc/src/tech/script-ref.md
+++ b/doc/src/tech/script-ref.md
@@ -475,7 +475,7 @@ any of them is `true`.
 
 <details>
   <summary>
-  <code>if_runcount_lt</code>/<code>if_runcount_le</code>/<code>if_runcount_gt</code>/<code>if_runcount_ge</code>
+  <code>if_runcount_lt</code>/<code>if_runcount_le</code>/<code>if_runcount_gt</code>/<code>if_runcount_ge</code>/<code>if_runcount_is</code>/<code>if_runcount_is_not</code>
   </summary>
 
 Example:
@@ -494,27 +494,7 @@ action = "..."
 run_every_n_ticks = "5+1"
 if_runcount_gt = 2
 action = "..."
-```
 
-Only run the action if the current runcount is:
-
- - less than (lt)
- - less than or equal to (le)
- - greater than (gt)
- - greater than or equal to (ge)
-
-the specified value.
-
-</details>
-
-<details>
-  <summary>
-  <code>if_runcount_is</code>
-  </summary>
-
-Example:
-
-```toml
 # Do something as soon as the "attack" slot is enabled,
 # but only if the script is run for the first time
 [[script]]
@@ -523,15 +503,21 @@ if_runcount_is = 0
 action = "..."
 
 # Do something when the script starts, but
-# only on the third, seventh, and ninth time it runs.
+# not on the third, seventh, and ninth time it runs.
 [[script]]
 run_on_playback_control = "Start"
 if_runcount_is = [ 3, 7, 9 ]
 action = "..."
 ```
 
-Only run the action if the current runcount is equal to any of the specified
-values.
+Only run the action if the current runcount is:
+
+ - less than a given value (`lt`)
+ - less than or equal to a given value (`le`)
+ - greater than a given value (`gt`)
+ - greater than or equal to a given value (`ge`)
+ - equal to any of the specified values (`is`)
+ - not equal to any of the specified values (`is_not`)
 
 </details>
 

--- a/engine/src/animation.rs
+++ b/engine/src/animation.rs
@@ -132,6 +132,22 @@ impl ScriptActionParams for SpriteAnimationScriptParams {
                 }
             }
         }
+        if let Some(f) = &self.if_frame_is_not {
+            match f {
+                OneOrMany::Single(f) => {
+                    if current_index == tracker.resolve_frame(self.frame_bookmark.as_ref(), f) {
+                        return Err(ScriptUpdateResult::NormalRun);
+                    }
+                }
+                OneOrMany::Many(f) => {
+                    for f in f.iter() {
+                        if current_index == tracker.resolve_frame(self.frame_bookmark.as_ref(), f) {
+                            return Err(ScriptUpdateResult::NormalRun);
+                        }
+                    }
+                }
+            }
+        }
         if let Some(reversed) = self.if_playing_reversed {
             if reversed != tracker.reversed {
                 return Err(ScriptUpdateResult::NormalRun);

--- a/engine/src/animation.rs
+++ b/engine/src/animation.rs
@@ -101,6 +101,60 @@ impl ScriptActionParams for SpriteAnimationScriptParams {
         _action_id: ActionId,
         (q_self,): &mut <Self::ShouldRunParam as SystemParam>::Item<'_, '_>,
     ) -> Result<(), ScriptUpdateResult> {
+        if let Some(oldanim_index) = tracker.carryover.frame {
+            if let Some(lt) = &self.if_oldanim_frame_lt {
+                if !(oldanim_index < *lt) {
+                    return Err(ScriptUpdateResult::NormalRun);
+                }
+            }
+            if let Some(le) = &self.if_oldanim_frame_le {
+                if !(oldanim_index <= *le) {
+                    return Err(ScriptUpdateResult::NormalRun);
+                }
+            }
+            if let Some(gt) = &self.if_oldanim_frame_gt {
+                if !(oldanim_index > *gt) {
+                    return Err(ScriptUpdateResult::NormalRun);
+                }
+            }
+            if let Some(ge) = &self.if_oldanim_frame_ge {
+                if !(oldanim_index >= *ge) {
+                    return Err(ScriptUpdateResult::NormalRun);
+                }
+            }
+            if let Some(f) = &self.if_oldanim_frame_was {
+                match f {
+                    OneOrMany::Single(f) => {
+                        if oldanim_index != *f {
+                            return Err(ScriptUpdateResult::NormalRun);
+                        }
+                    }
+                    OneOrMany::Many(f) => {
+                        for f in f.iter() {
+                            if oldanim_index != *f {
+                                return Err(ScriptUpdateResult::NormalRun);
+                            }
+                        }
+                    }
+                }
+            }
+            if let Some(f) = &self.if_oldanim_frame_was_not {
+                match f {
+                    OneOrMany::Single(f) => {
+                        if oldanim_index == *f {
+                            return Err(ScriptUpdateResult::NormalRun);
+                        }
+                    }
+                    OneOrMany::Many(f) => {
+                        for f in f.iter() {
+                            if oldanim_index == *f {
+                                return Err(ScriptUpdateResult::NormalRun);
+                            }
+                        }
+                    }
+                }
+            }
+        }
         let current_index = FrameId::from_sprite_index(q_self.get(entity).unwrap().0.index);
         if let Some(lt) = &self.if_frame_lt {
             if !(current_index < tracker.resolve_frame(self.frame_bookmark.as_ref(), lt)) {

--- a/engine/src/assets/animation.rs
+++ b/engine/src/assets/animation.rs
@@ -52,6 +52,7 @@ pub struct SpriteAnimationScriptParams {
     pub if_frame_gt: Option<FrameIndexOrBookmark>,
     pub if_frame_ge: Option<FrameIndexOrBookmark>,
     pub if_frame_is: Option<OneOrMany<FrameIndexOrBookmark>>,
+    pub if_frame_is_not: Option<OneOrMany<FrameIndexOrBookmark>>,
     pub if_playing_reversed: Option<bool>,
 }
 
@@ -175,6 +176,7 @@ impl FrameId {
         debug_assert!(self.0 != 0);
         (self.0 - 1) as usize
     }
+
     pub fn from_sprite_index(i: usize) -> Self {
         FrameId(i as u32 + 1)
     }
@@ -188,6 +190,7 @@ impl Default for FrameId {
 
 impl std::ops::Add<FrameId> for FrameId {
     type Output = FrameId;
+
     fn add(self, rhs: FrameId) -> Self::Output {
         FrameId(self.0 + rhs.0 - 1)
     }
@@ -195,6 +198,7 @@ impl std::ops::Add<FrameId> for FrameId {
 
 impl std::ops::Add<u32> for FrameId {
     type Output = FrameId;
+
     fn add(self, rhs: u32) -> Self::Output {
         FrameId(self.0 + rhs)
     }
@@ -202,6 +206,7 @@ impl std::ops::Add<u32> for FrameId {
 
 impl std::ops::Sub<FrameId> for FrameId {
     type Output = FrameId;
+
     fn sub(self, rhs: FrameId) -> Self::Output {
         FrameId(self.0 - (rhs.0 - 1))
     }
@@ -209,6 +214,7 @@ impl std::ops::Sub<FrameId> for FrameId {
 
 impl std::ops::Sub<u32> for FrameId {
     type Output = FrameId;
+
     fn sub(self, rhs: u32) -> Self::Output {
         FrameId(self.0 - rhs)
     }

--- a/engine/src/assets/animation.rs
+++ b/engine/src/assets/animation.rs
@@ -53,6 +53,12 @@ pub struct SpriteAnimationScriptParams {
     pub if_frame_ge: Option<FrameIndexOrBookmark>,
     pub if_frame_is: Option<OneOrMany<FrameIndexOrBookmark>>,
     pub if_frame_is_not: Option<OneOrMany<FrameIndexOrBookmark>>,
+    pub if_oldanim_frame_lt: Option<FrameId>,
+    pub if_oldanim_frame_le: Option<FrameId>,
+    pub if_oldanim_frame_gt: Option<FrameId>,
+    pub if_oldanim_frame_ge: Option<FrameId>,
+    pub if_oldanim_frame_was: Option<OneOrMany<FrameId>>,
+    pub if_oldanim_frame_was_not: Option<OneOrMany<FrameId>>,
     pub if_playing_reversed: Option<bool>,
 }
 

--- a/engine/src/assets/script.rs
+++ b/engine/src/assets/script.rs
@@ -1,9 +1,8 @@
 use bevy::reflect::TypePath;
 
+use super::config::DynamicConfigValue;
 use crate::data::*;
 use crate::prelude::*;
-
-use super::config::DynamicConfigValue;
 
 /// Scripted Sequence Asset type
 ///
@@ -82,6 +81,7 @@ pub struct CommonScriptParams {
     #[serde(default)]
     pub forbid_slots_any: Vec<String>,
     pub if_runcount_is: Option<OneOrMany<u32>>,
+    pub if_runcount_is_not: Option<OneOrMany<u32>>,
     pub if_runcount_lt: Option<u32>,
     pub if_runcount_le: Option<u32>,
     pub if_runcount_gt: Option<u32>,
@@ -146,17 +146,11 @@ pub enum CommonScriptAction {
     /// Spawn a new entity to run a script
     SpawnScript { asset_key: String },
     /// Enable a Slot
-    SlotEnable {
-        slot: String,
-    },
+    SlotEnable { slot: String },
     /// Disable a Slot
-    SlotDisable {
-        slot: String,
-    },
+    SlotDisable { slot: String },
     /// Toggle a Slot
-    SlotToggle {
-        slot: String,
-    },
+    SlotToggle { slot: String },
     /// Play a sound (precise timing based on action's trigger condition)
     PlayAudio {
         asset_key: String,
@@ -239,7 +233,8 @@ pub enum ExtendedScriptWorkaroundInner<ExtRunIf, ExtAction> {
     CC(Flattened<CommonScriptRunIf, CommonScriptAction>),
 }
 
-impl<ExtParams, ExtRunIf, ExtAction> From<ExtendedScriptWorkaround<ExtParams, ExtRunIf, ExtAction>>
+impl<ExtParams, ExtRunIf, ExtAction>
+    From<ExtendedScriptWorkaround<ExtParams, ExtRunIf, ExtAction>>
     for ExtendedScript<ExtParams, ExtRunIf, ExtAction>
 {
     fn from(

--- a/engine/src/script/common.rs
+++ b/engine/src/script/common.rs
@@ -405,6 +405,15 @@ impl ScriptActionParams for CommonScriptParams {
                 return Err(ScriptUpdateResult::NormalRun);
             }
         }
+        if let Some(eq) = &self.if_runcount_is_not {
+            let b = match eq {
+                OneOrMany::Single(x) => *x == tracker.runcount,
+                OneOrMany::Many(x) => x.iter().any(|x| *x == tracker.runcount),
+            };
+            if b {
+                return Err(ScriptUpdateResult::NormalRun);
+            }
+        }
         match (&self.if_previous_script_key, &tracker.old_key) {
             (None, _) => {}
             (Some(req), Some(old)) if req == old => {},


### PR DESCRIPTION
New features:
 - add `if_runcount_is_not` and `if_frame_is_not` parameters (for "not equals" checking)
 - add `if_oldanim_frame_*` parameters
   - allow you to do things based on where the previously-playing animation left off
   - use in combination with `if_previous_script_key`

Internal changes:

There is now a general "data carry-over" mechanism in the script runtime, allowing the previously-running script to prepare some data to be made available to the newly-starting script.

For now, this is only used for the "old animation frame index" feature.

But in the future, we could use it to easily add other pieces of data that should be retained from previously-running scripts, should we want to.