### PR TITLE
Game restart bug fixes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -159,3 +159,7 @@ branch = "fixed_update_0.13"
 
 [dependencies.rapier2d]
 version = "0.18"
+
+# Unavoidable with how Bevy is designed
+[lints.clippy]
+type_complexity = "allow"

--- a/game/src/game/player/mod.rs
+++ b/game/src/game/player/mod.rs
@@ -142,9 +142,9 @@ impl Default for Passives {
 
 impl Passives {
     // TODO: pass in slice of passives, filter the locked passives on it
-    fn new_with(passive: Passive) -> Self {
-        Passives::default()
-    }
+    // fn new_with(passive: Passive) -> Self {
+    //     Passives::default()
+    // }
 
     fn gain(&mut self) {
         // TODO: add checks for no passives remaining
@@ -171,7 +171,7 @@ pub enum Passive {
     Speedy,
 }
 
-fn debug_player_states(
+fn _debug_player_states(
     query: Query<
         AnyOf<(
             Ref<Running>,
@@ -549,6 +549,7 @@ impl Transitionable<Stealthing> for CanStealth {
 /// If a player attack lands, locks their velocity for the configured number of ticks'
 // Tracks the attack entity which last caused the hirfreeze affect. and ticks since triggered
 // (this way the same attack doesn't trigger it multiple times)
+#[allow(dead_code)]
 #[derive(Component, Default, Debug)]
 pub struct HitFreezeTime(u32, Option<Entity>);
 
@@ -681,7 +682,6 @@ fn load_player_config(
     cfgs: Res<Assets<DynamicConfig>>,
     preloaded: Res<PreloadedAssets>,
     mut player_config: ResMut<PlayerConfig>,
-    mut commands: Commands,
     mut initialized_config: Local<bool>,
 ) {
     // convert from asset key string to bevy handle
@@ -702,19 +702,16 @@ fn load_player_config(
         *initialized_config = true;
     }
     for ev in ev_asset.read() {
-        match ev {
-            AssetEvent::Modified { id } => {
-                if let Some(cfg) = cfgs.get(*id) {
-                    if cfg_handle.id() == *id {
-                        println!("before:");
-                        dbg!(&player_config);
-                        update_player_config(&mut player_config, cfg);
-                        println!("after:");
-                        dbg!(&player_config);
-                    }
+        if let AssetEvent::Modified { id } = ev {
+            if let Some(cfg) = cfgs.get(*id) {
+                if cfg_handle.id() == *id {
+                    println!("before:");
+                    dbg!(&player_config);
+                    update_player_config(&mut player_config, cfg);
+                    println!("after:");
+                    dbg!(&player_config);
                 }
-            },
-            _ => {},
+            }
         }
     }
 }
@@ -765,6 +762,7 @@ fn load_player_stats(
 }
 
 /// Extend with additional parameter Stats
+#[allow(clippy::enum_variant_names)]
 #[derive(Clone, Copy, Eq, PartialEq, Hash, Debug)]
 pub enum StatType {
     MoveVelMax,
@@ -887,7 +885,7 @@ fn player_new_stats_mod(
             player_stats.update_stats(&modifier);
         }
 
-        sprite.color = modifier.effect_col.clone();
+        sprite.color = modifier.effect_col;
 
         modifier.time_remaining -= time.delta_seconds();
 
@@ -930,7 +928,7 @@ pub fn player_dash_fx(
     mut commands: Commands,
     asset: Res<DashIconAssetHandle>,
 ) {
-    for (global_tr, facing, dashing, stealthing_maybe) in query.iter() {
+    for (global_tr, facing, _dashing, stealthing_maybe) in query.iter() {
         let pos = global_tr.translation();
 
         // Code for potentially interpolating position

--- a/game/src/game/player/mod.rs
+++ b/game/src/game/player/mod.rs
@@ -1,11 +1,10 @@
 mod player_anim;
 mod player_behaviour;
 use bevy::utils::hashbrown::HashMap;
+use leafwing_input_manager::action_state::ActionState;
 use leafwing_input_manager::axislike::VirtualAxis;
-use leafwing_input_manager::{
-    action_state::ActionState, input_map::InputMap, Actionlike,
-    InputManagerBundle,
-};
+use leafwing_input_manager::input_map::InputMap;
+use leafwing_input_manager::{Actionlike, InputManagerBundle};
 use player_anim::PlayerAnimationPlugin;
 use player_behaviour::PlayerBehaviorPlugin;
 use rapier2d::geometry::{Group, InteractionGroups};
@@ -81,7 +80,7 @@ pub enum PlayerStateSet {
     Animation,
 }
 
-//TODO: change to player spawnpoint
+// TODO: change to player spawnpoint
 #[derive(Bundle, LdtkEntity, Default)]
 pub struct PlayerBlueprintBundle {
     marker: PlayerBlueprint,
@@ -142,14 +141,15 @@ impl Default for Passives {
 }
 
 impl Passives {
-    //TODO: pass in slice of passives, filter the locked passives on it
+    // TODO: pass in slice of passives, filter the locked passives on it
     fn new_with(passive: Passive) -> Self {
         Passives::default()
     }
+
     fn gain(&mut self) {
-        //TODO: add checks for no passives remaining
-        //TODO add limit on gaining past max passive slots?
-        //does nothing if there are no more passives to gain
+        // TODO: add checks for no passives remaining
+        // TODO add limit on gaining past max passive slots?
+        // does nothing if there are no more passives to gain
         let mut rng = rand::thread_rng();
         if !self.locked.is_empty() {
             let i = rng.gen_range(0..self.locked.len());
@@ -253,7 +253,7 @@ fn setup_player(
     config: Res<PlayerConfig>,
 ) {
     for (mut xf_gent, e_gent, parent) in q.iter_mut() {
-        //TODO: proper way of ensuring z is correct
+        // TODO: proper way of ensuring z is correct
         xf_gent.translation.z = 15.0 * 0.000001;
         println!("{:?}", xf_gent);
         let e_gfx = commands.spawn(()).id();
@@ -272,7 +272,7 @@ fn setup_player(
                         10.0,
                         InteractionGroups {
                             memberships: PLAYER,
-                            //should be more specific
+                            // should be more specific
                             filter: Group::all(),
                         },
                     ),
@@ -302,8 +302,8 @@ fn setup_player(
                 current: config.max_health,
                 max: config.max_health,
             },
-            //have to use builder here *i think* because of different types between keycode and
-            //axis
+            // have to use builder here *i think* because of different types between keycode and
+            // axis
             InputManagerBundle::<PlayerAction> {
                 action_state: ActionState::default(),
                 input_map: InputMap::default()
@@ -327,7 +327,7 @@ fn setup_player(
                     .with(PlayerAction::Whirl, KeyCode::KeyL)
                     .with(PlayerAction::Stealth, KeyCode::KeyI),
             },
-            //bundling things up becuase we reached max tuple
+            // bundling things up becuase we reached max tuple
             (
                 Falling,
                 CanDash {
@@ -347,7 +347,7 @@ fn setup_player(
             StateDespawnMarker,
             Passives::default(),
         ));
-        //unparent from the level
+        // unparent from the level
         if let Ok(parent) = parent_query.get(parent.get()) {
             commands.entity(parent).remove_children(&[e_gent]);
         }
@@ -426,11 +426,11 @@ impl GenericState for Jumping {}
 #[component(storage = "SparseSet")]
 pub struct Grounded;
 impl GentState for Grounded {}
-//cant be Idle or Running if not Grounded
+// cant be Idle or Running if not Grounded
 impl Transitionable<Jumping> for Grounded {
     type Removals = (Grounded, Idle, Running, Whirling);
 }
-//cant be Idle or Running if not Grounded
+// cant be Idle or Running if not Grounded
 impl Transitionable<Falling> for Grounded {
     type Removals = (Grounded, Idle, Running, Whirling);
 }
@@ -547,7 +547,7 @@ impl Transitionable<Stealthing> for CanStealth {
 // and provide storage for that behaviours state
 
 /// If a player attack lands, locks their velocity for the configured number of ticks'
-//Tracks the attack entity which last caused the hirfreeze affect. and ticks since triggered
+// Tracks the attack entity which last caused the hirfreeze affect. and ticks since triggered
 // (this way the same attack doesn't trigger it multiple times)
 #[derive(Component, Default, Debug)]
 pub struct HitFreezeTime(u32, Option<Entity>);
@@ -567,12 +567,13 @@ impl WallSlideTime {
     fn sliding(&self, cfg: &PlayerConfig) -> bool {
         self.0 <= cfg.max_coyote_time * 2.0
     }
+
     fn strict_sliding(&self, cfg: &PlayerConfig) -> bool {
         self.0 <= cfg.max_coyote_time * 1.0
     }
 }
 
-///Tracks the cooldown for the available energy for the players whirl
+/// Tracks the cooldown for the available energy for the players whirl
 #[derive(Component, Default, Debug)]
 pub struct WhirlAbility {
     pub energy: f32,
@@ -787,7 +788,7 @@ pub struct StatusModifier {
     time_remaining: f32,
 }
 
-//TODO: move to attack
+// TODO: move to attack
 impl StatusModifier {
     pub fn basic_ice_spider() -> Self {
         Self {
@@ -799,7 +800,7 @@ impl StatusModifier {
             scalar: vec![0.5],
             delta: vec![],
             //            effect_col: Color::hex("C2C9C9").unwrap(),
-            effect_col: Color::hex("0099CC").unwrap(), // For More Visible Effect
+            effect_col: Color::hex("0099CC").unwrap(), /* For More Visible Effect */
             time_remaining: 2.0,
         }
     }
@@ -934,17 +935,17 @@ pub fn player_dash_fx(
 
         // Code for potentially interpolating position
         // Not deemed necessary due to sufficient sprite overlap
-        //let dir = Vec3::new(
+        // let dir = Vec3::new(
         //    config.dash_velocity * facing.direction(),
         //    0.0,
         //    0.0,
         //);
-        //let lpos = pos + dir * 0.5;
-        //if dashing.is_added() {
+        // let lpos = pos + dir * 0.5;
+        // if dashing.is_added() {
         //
         //} else
         {
-            //let dir = Vec2::new(
+            // let dir = Vec2::new(
             //    config.dash_velocity * facing.direction(),
             //    0.0,
             //);
@@ -992,7 +993,7 @@ pub fn dash_icon_fx(
     }
 }
 
-///Resets the players cooldowns/energy on hit of a stealthed critical hit
+/// Resets the players cooldowns/energy on hit of a stealthed critical hit
 pub fn on_hit_stealth_reset(
     query: Query<&Attack, (Added<Hit>, With<Crit>, With<Stealthed>)>,
     mut attacker_skills: Query<(
@@ -1022,7 +1023,7 @@ pub fn on_hit_stealth_reset(
     }
 }
 
-///Exits player Stealthing state when a stealthed attack first hits
+/// Exits player Stealthing state when a stealthed attack first hits
 pub fn on_hit_exit_stealthing(
     query: Query<&Attack, (Added<Hit>, With<Stealthed>)>,
     mut attacker_query: Query<(&Gent, &mut TransitionQueue), With<Player>>,

--- a/game/src/game/player/player_behaviour.rs
+++ b/game/src/game/player/player_behaviour.rs
@@ -244,9 +244,9 @@ fn player_idle(
 
 fn player_move(
     config: Res<PlayerConfig>,
-    stats: Res<PlayerStats>,
     mut q_gent: Query<
         (
+            &PlayerStats,
             &mut LinearVelocity,
             &ActionState<PlayerAction>,
             &mut Facing,
@@ -257,8 +257,15 @@ fn player_move(
         (Without<Knockback>, With<Player>),
     >,
 ) {
-    for (mut velocity, action_state, mut facing, grounded, stealth, dashing) in
-        q_gent.iter_mut()
+    for (
+        stats,
+        mut velocity,
+        action_state,
+        mut facing,
+        grounded,
+        stealth,
+        dashing,
+    ) in q_gent.iter_mut()
     {
         let mut direction: f32 = 0.0;
         // Uses high starting acceleration, to emulate "shoving" off the ground/start

--- a/game/src/game/player/player_behaviour.rs
+++ b/game/src/game/player/player_behaviour.rs
@@ -1,19 +1,3 @@
-use crate::camera::{CameraRig, CameraShake};
-use crate::game::attack::{Attack, SelfPushback, Stealthed};
-use crate::game::enemy::Enemy;
-use crate::game::gentstate::{Facing, TransitionQueue, Transitionable};
-use crate::game::player::{
-    Attacking, CanAttack, CanDash, CoyoteTime, Dashing, Falling, Grounded,
-    HitFreezeTime, Idle, Jumping, Player, PlayerAction, PlayerConfig,
-    PlayerGfx, PlayerStateSet, Running, WallSlideTime, WhirlAbility,
-};
-use crate::prelude::{
-    any_with_component, resource_changed, App, BuildChildren, Commands,
-    DetectChanges, Direction2d, Entity, GameTickUpdate, GameTime, Has,
-    IntoSystemConfigs, Plugin, Query, Res, ResMut, Transform, TransformBundle,
-    With, Without,
-};
-
 use bevy::sprite::Sprite;
 use bevy::transform::TransformSystem::TransformPropagate;
 use glam::{Vec2, Vec2Swizzles, Vec3Swizzles};
@@ -30,14 +14,29 @@ use theseeker_engine::physics::{
 use theseeker_engine::script::ScriptPlayer;
 
 use super::{
-    dash_icon_fx, player_dash_fx, player_new_stats_mod, CanStealth, DashIcon,
-    JumpCount, Knockback, PlayerStats, Pushback, StatType, Stealthing,
+    dash_icon_fx, player_dash_fx, player_new_stats_mod, AttackBundle,
+    CanStealth, DashIcon, JumpCount, KillCount, Knockback, Passives,
+    PlayerStats, Pushback, StatType, Stealthing, Whirling,
 };
-use super::{AttackBundle, KillCount, Passives, Whirling};
+use crate::camera::{CameraRig, CameraShake};
+use crate::game::attack::{Attack, SelfPushback, Stealthed};
+use crate::game::enemy::Enemy;
+use crate::game::gentstate::{Facing, TransitionQueue, Transitionable};
+use crate::game::player::{
+    Attacking, CanAttack, CanDash, CoyoteTime, Dashing, Falling, Grounded,
+    HitFreezeTime, Idle, Jumping, Player, PlayerAction, PlayerConfig,
+    PlayerGfx, PlayerStateSet, Running, WallSlideTime, WhirlAbility,
+};
+use crate::prelude::{
+    any_with_component, resource_changed, App, BuildChildren, Commands,
+    DetectChanges, Direction2d, Entity, GameTickUpdate, GameTime, Has,
+    IntoSystemConfigs, Plugin, Query, Res, ResMut, Transform, TransformBundle,
+    With, Without,
+};
 
-///Player behavior systems.
-///Do stuff here in states and add transitions to other states by pushing
-///to a TransitionQueue.
+/// Player behavior systems.
+/// Do stuff here in states and add transitions to other states by pushing
+/// to a TransitionQueue.
 pub(crate) struct PlayerBehaviorPlugin;
 
 impl Plugin for PlayerBehaviorPlugin {
@@ -79,8 +78,8 @@ impl Plugin for PlayerBehaviorPlugin {
                 )
                     .in_set(PlayerStateSet::Behavior)
                     .before(update_sprite_colliders),
-                //consider a set for all movement/systems modify velocity, then collisions/move
-                //moves based on velocity
+                // consider a set for all movement/systems modify velocity, then collisions/move
+                // moves based on velocity
                 (
                     // hitfreeze,
                     set_movement_slots,
@@ -157,7 +156,7 @@ pub fn player_can_stealth(
         q_gent.iter_mut()
     {
         can_stealth.remaining_cooldown -= 1.0 / time.hz as f32;
-        //Return to base sprite color when exiting stealth
+        // Return to base sprite color when exiting stealth
         if can_stealth.is_added() {
             let mut sprite = sprites.get_mut(gent.e_gfx).unwrap();
             sprite.color = sprite.color.with_a(1.0);
@@ -174,7 +173,7 @@ pub fn player_can_stealth(
     }
 }
 
-//TODO: change to using Added<attack::Hit>
+// TODO: change to using Added<attack::Hit>
 fn hitfreeze(
     mut player_q: Query<
         (
@@ -379,8 +378,8 @@ fn player_run(
         if action_state.pressed(&PlayerAction::Move) {
             direction = action_state.value(&PlayerAction::Move);
         }
-        //should it account for decel and only transition to idle when player stops completely?
-        //shouldnt be able to transition to idle if we also jump
+        // should it account for decel and only transition to idle when player stops completely?
+        // shouldnt be able to transition to idle if we also jump
         if direction == 0.0 && action_state.released(&PlayerAction::Jump) {
             transitions.push(Running::new_transition(Idle));
         }
@@ -559,7 +558,7 @@ pub fn player_collisions(
         // so the velocity is only stopped in the x direction, but not the y, so without the extra
         // check with the new velocity and position, the y might clip the player through the roof
         // of the corner.
-        //if we are not moving, we can not shapecast in direction of movement
+        // if we are not moving, we can not shapecast in direction of movement
         while let Ok(shape_dir) = Direction2d::new(projected_velocity) {
             if let Some((e, first_hit)) = spatial_query.shape_cast(
                 possible_pos,
@@ -569,23 +568,23 @@ pub fn player_collisions(
                 interaction,
                 Some(entity),
             ) {
-                //If we are colliding with an enemy
+                // If we are colliding with an enemy
                 if let Ok((enemy, mut collider)) = q_enemy.get_mut(e) {
-                    //change collision groups to only include ground so on the next loop we can
-                    //ignore enemies/check our ground collision
+                    // change collision groups to only include ground so on the next loop we can
+                    // ignore enemies/check our ground collision
                     interaction = InteractionGroups {
                         memberships: PLAYER,
                         filter: GROUND,
                     };
                     match first_hit.status {
-                        //if we are not yet inside the enemy, collide, but not if we are falling
-                        //from above
+                        // if we are not yet inside the enemy, collide, but not if we are falling
+                        // from above
                         TOIStatus::Converged | TOIStatus::OutOfIterations => {
                             // if we are also dashing, or whirling, ignore the collision entirely
                             if dashing.is_none() && whirling.is_none() {
                                 let sliding_plane =
                                     into_vec2(first_hit.normal1);
-                                //configurable theshold for collision normal/sliding plane in case of physics instability
+                                // configurable theshold for collision normal/sliding plane in case of physics instability
                                 let threshold = 0.000001;
                                 if !(1. - threshold..=1. + threshold)
                                     .contains(&sliding_plane.y)
@@ -598,8 +597,8 @@ pub fn player_collisions(
                                 }
                             }
                         },
-                        //if we are already inside, modify the enemies collision group and add
-                        //Inside so next frame we dont collide with them
+                        // if we are already inside, modify the enemies collision group and add
+                        // Inside so next frame we dont collide with them
                         TOIStatus::Penetrating => {
                             collider.0.set_collision_groups(
                                 InteractionGroups {
@@ -611,10 +610,10 @@ pub fn player_collisions(
                                 .entity(enemy)
                                 .insert(crate::game::enemy::Inside);
                         },
-                        //maybe failed never happens?
+                        // maybe failed never happens?
                         TOIStatus::Failed => println!("failed"),
                     }
-                //otherwise we are colliding with the ground
+                // otherwise we are colliding with the ground
                 } else {
                     match first_hit.status {
                         TOIStatus::Converged | TOIStatus::OutOfIterations => {
@@ -773,9 +772,9 @@ fn player_grounded(
             }
         };
 
-        //just pressed seems to get missed sometimes... but we need it because pressed makes you
-        //jump continuously if held
-        //known issue https://github.com/bevyengine/bevy/issues/6183
+        // just pressed seems to get missed sometimes... but we need it because pressed makes you
+        // jump continuously if held
+        // known issue https://github.com/bevyengine/bevy/issues/6183
         if action_state.just_pressed(&PlayerAction::Jump) {
             jump_count.0 = 1;
             transitions.push(Grounded::new_transition(Jumping))
@@ -824,12 +823,12 @@ fn player_falling(
         if let Some((hit_entity, toi)) =
             hits.cast(&spatial_query, &transform, Some(entity))
         {
-            //if we are ~touching the ground
+            // if we are ~touching the ground
             if (toi.toi + velocity.y * (1.0 / time.hz) as f32)
                 < GROUNDED_THRESHOLD
             {
                 transitions.push(Falling::new_transition(Grounded));
-                //stop falling
+                // stop falling
                 velocity.y = 0.0;
                 transform.translation.y =
                     transform.translation.y - toi.toi + GROUNDED_THRESHOLD;
@@ -848,7 +847,7 @@ fn player_falling(
                 velocity.y = 0.0;
                 jump_count.0 -= 1;
 
-                //println!("air jump: {}", jump_count.0);
+                // println!("air jump: {}", jump_count.0);
                 transitions.push(Falling::new_transition(Jumping))
             }
             if velocity.y > 0.0 {
@@ -1011,7 +1010,7 @@ fn player_attack(
                         0.0, 0.0, 0.0,
                     )),
                     AnimationCollider(gent.e_gfx),
-                    //TODO: ? ColliderMeta
+                    // TODO: ? ColliderMeta
                     Collider::empty(InteractionGroups::new(
                         PLAYER_ATTACK,
                         ENEMY_HURT,
@@ -1041,15 +1040,15 @@ fn player_attack(
         }
 
         attacking.ticks += 1;
-        //if we are in the later half of attacking and another attack input was pressed,
-        //indicate an immediate follow up on animation end
+        // if we are in the later half of attacking and another attack input was pressed,
+        // indicate an immediate follow up on animation end
         if attacking.ticks >= Attacking::MAX * 8 - 8
             && action_state.just_pressed(&PlayerAction::Attack)
         {
             attacking.followup = true;
         }
 
-        //leave attacking state
+        // leave attacking state
         if attacking.ticks == Attacking::MAX * 8 {
             if attacking.followup {
                 transitions.push(Attacking::new_transition(CanAttack {
@@ -1088,8 +1087,8 @@ pub fn player_whirl(
         ),
         (With<Player>, Without<Dashing>),
     >,
-    //attacks which have had their collider changed by the AnimationCollider system
-    //TODO: need to not change collider unless there is a collider?
+    // attacks which have had their collider changed by the AnimationCollider system
+    // TODO: need to not change collider unless there is a collider?
     attack_query: Query<
         &Attack,
         (
@@ -1117,16 +1116,16 @@ pub fn player_whirl(
             || whirling.ticks < Whirling::MIN_TICKS
         {
             if let Some(attack_entity) = whirling.attack_entity {
-                //if the attack entities collider was changed, set the attack to none
+                // if the attack entities collider was changed, set the attack to none
                 if attack_query.get(attack_entity).is_err() {
                     whirling.attack_entity = None;
                 }
-            //if there is no attack, spawn a new one
+            // if there is no attack, spawn a new one
             } else {
                 let new_attack = commands
                     .spawn((
                         AttackBundle {
-                            //lifetime of two frames...
+                            // lifetime of two frames...
                             attack: Attack::new(24, entity),
                             collider: Collider::empty(InteractionGroups::new(
                                 PLAYER_ATTACK,
@@ -1146,7 +1145,7 @@ pub fn player_whirl(
                 whirling.attack_entity = Some(new_attack);
             }
         } else {
-            //leave whirling state if button is not pressed and we are past min ticks
+            // leave whirling state if button is not pressed and we are past min ticks
             if whirling.ticks >= Whirling::MIN_TICKS {
                 transitions.push(Whirling::new_transition(
                     CanAttack::default(),

--- a/game/src/graphics/dmg_numbers.rs
+++ b/game/src/graphics/dmg_numbers.rs
@@ -88,6 +88,7 @@ fn instance(
                     top: Val::Px(screen_position.y),
                     ..default()
                 }),
+                StateDespawnMarker,
             ));
         }
     }

--- a/game/src/graphics/dmg_numbers.rs
+++ b/game/src/graphics/dmg_numbers.rs
@@ -1,10 +1,12 @@
+use bevy::prelude::*;
+use theseeker_engine::physics::Collider;
+use theseeker_engine::prelude::{GameTickUpdate, GameTime};
+
 use crate::camera::MainCamera;
 use crate::game::attack::{apply_attack_damage, DamageInfo};
 use crate::game::player::Player;
 use crate::prelude::Update;
-use bevy::prelude::*;
-use theseeker_engine::physics::Collider;
-use theseeker_engine::prelude::{GameTickUpdate, GameTime};
+use crate::StateDespawnMarker;
 
 pub struct DmgNumbersPlugin;
 
@@ -26,7 +28,10 @@ struct DmgNumber(Vec3, f64);
 fn instance(
     mut commands: Commands,
     asset_server: Res<AssetServer>,
-    entity_with_hp: Query<(&GlobalTransform, Option<&Collider>), Without<Player>>,
+    entity_with_hp: Query<
+        (&GlobalTransform, Option<&Collider>),
+        Without<Player>,
+    >,
     mut damage_events: EventReader<DamageInfo>,
     game_time: Res<GameTime>,
     q_cam: Query<(&GlobalTransform, &Camera), With<MainCamera>>,
@@ -36,14 +41,17 @@ fn instance(
     };
 
     for damage_info in damage_events.read() {
-        if let Ok((transform, collider)) = entity_with_hp.get(damage_info.target) {
+        if let Ok((transform, collider)) =
+            entity_with_hp.get(damage_info.target)
+        {
             let mut world_position = transform.translation();
 
             // Makes the number start above the collider, if it exists
             world_position += match collider {
                 Some(collider) => {
                     let above_hb_offset = 11.0;
-                    let collider_height = collider.0.compute_aabb().half_extents().y;
+                    let collider_height =
+                        collider.0.compute_aabb().half_extents().y;
                     Vec3::new(
                         1.0,
                         collider_height + above_hb_offset,
@@ -60,7 +68,8 @@ fn instance(
             commands.spawn((
                 DmgNumber(
                     world_position,
-                    game_time.tick() as f64 / game_time.hz + game_time.last_update().as_secs_f64(),
+                    game_time.tick() as f64 / game_time.hz
+                        + game_time.last_update().as_secs_f64(),
                 ),
                 TextBundle::from_section(
                     format!("{}", damage_info.amount),
@@ -76,10 +85,10 @@ fn instance(
                         } else {
                             Color::WHITE
                         },
-                        //TODO:
-                        //if backstab, red?
-                        //TODO:
-                        //can we mix the colors to determine final color?
+                        // TODO:
+                        // if backstab, red?
+                        // TODO:
+                        // can we mix the colors to determine final color?
                     },
                 )
                 .with_style(Style {
@@ -110,7 +119,8 @@ fn update_number(
     };
     let max_time = 6.0;
 
-    for (entity, mut dmg_number, mut style, mut text) in dmg_numer_q.iter_mut() {
+    for (entity, mut dmg_number, mut style, mut text) in dmg_numer_q.iter_mut()
+    {
         let text_style = &mut text.sections[0].style;
         // This way the floating text position is dependent on the gametick time,
         // so if the game is paused, the floating numbers will pause as well.
@@ -119,7 +129,8 @@ fn update_number(
             - dmg_number.1;
 
         // apply a little wobble affect, and start each with a random different phase
-        let global_pos = dmg_number.0 + Vec3::new(0.0, 3.0 * elapsed_time as f32, 0.0);
+        let global_pos =
+            dmg_number.0 + Vec3::new(0.0, 3.0 * elapsed_time as f32, 0.0);
         let screen_position = camera
             .world_to_viewport(camera_transform, global_pos)
             .unwrap();


### PR DESCRIPTION
Fixes #122

### Main changes
- `DmgNumber` now gets cleaned up between app state changes (fixes `DmgNumber` related panic)
- Changed `PlayerStats` type from `Resource` into `Component`. (fixes slow stats persisting after restart)

This also includes a warning clean up + globally ignore `type_complexity` setting in Cargo.toml which should reduce the project's warning total.