### PR TITLE
Bow Attack + Weapon Swap

### DIFF
--- a/assets/player.cfg.toml
+++ b/assets/player.cfg.toml
@@ -86,3 +86,6 @@ melee_pushback_ticks = 12.0
 
 # Number of kills to trigger passive gain
 passive_gain_rate = 3.0
+
+# Velocity of the projectiles fired by the Bow weapon
+arrow_velocity = 1000.0

--- a/assets/player.cfg.toml
+++ b/assets/player.cfg.toml
@@ -33,7 +33,7 @@ fall_accel = 4.5
 # How many seconds does our characters innate hover boots work?
 max_coyote_time = 0.1
 
-# Onlly applies in the downward y direction while the player is falling
+# Only applies in the downward y direction while the player is falling
 # and trying to walk into the wall
 sliding_friction = 0.25
 

--- a/assets/player.cfg.toml
+++ b/assets/player.cfg.toml
@@ -84,6 +84,18 @@ melee_pushback = 60.0
 # Ticks for melee knockback velocity; determines how long movement is locked for
 melee_pushback_ticks = 12.0
 
+# Pushback velocity on basic bow shots
+bow_self_pushback = 60.0
+
+# Ticks for bow pushback velocity; determines how long movement is locked for
+bow_self_pushback_ticks = 3.0
+
+# Knockback velocity applied to enemy on basic bow hit
+bow_pushback = 60.0
+
+# Ticks for melee knockback velocity; determines how long movement is locked for
+bow_pushback_ticks = 12.0
+
 # Number of kills to trigger passive gain
 passive_gain_rate = 3.0
 

--- a/assets/player.cfg.toml
+++ b/assets/player.cfg.toml
@@ -84,6 +84,9 @@ melee_pushback = 60.0
 # Ticks for melee knockback velocity; determines how long movement is locked for
 melee_pushback_ticks = 12.0
 
+# Base bow attack damage
+bow_attack_damage = 20.0
+
 # Pushback velocity on basic bow shots
 bow_self_pushback = 60.0
 

--- a/engine/src/physics.rs
+++ b/engine/src/physics.rs
@@ -395,7 +395,7 @@ fn init_physics_world(mut world: ResMut<PhysicsWorld>) {
 ///
 /// Make sure if you are reading from this in a system, you run after this finishes
 ///
-/// TODO make sure this always runs after the GameTickUpdate; consider creating a seperate
+/// TODO make sure this always runs after the GameTickUpdate; consider creating a separate
 /// [`ScheduleLabel`] for immediately after transform propagation
 pub fn update_query_pipeline(
     // Mutable reference because collider data is stored in an Arena that pipeline modifies

--- a/game/src/game/attack/arc_attack.rs
+++ b/game/src/game/attack/arc_attack.rs
@@ -45,13 +45,18 @@ impl Projectile {
     }
 }
 
+/// Marker that identifies arrows shot by the Player.
+#[derive(Component)]
+pub struct Arrow;
+
 /// Applies gravity to the projectile
+/// It will not add gravity to Arrows shot by the Player.
 pub fn arc_projectile(
     mut query: Query<
         (
             &mut Transform,
-            &Collider,
             &mut Projectile,
+            Has<Arrow>,
         ),
         With<Attack>,
     >,
@@ -59,8 +64,10 @@ pub fn arc_projectile(
     time: Res<GameTime>,
 ) {
     let fall_accel = config.fall_accel;
-    for (mut transform, collider, mut projectile) in query.iter_mut() {
-        projectile.vel.0.y -= fall_accel;
+    for (mut transform, mut projectile, arrow) in query.iter_mut() {
+        if !arrow {
+            projectile.vel.0.y -= fall_accel;
+        }
         let z = transform.translation.z;
         transform.translation = (transform.translation.xy()
             + *projectile.vel * (1.0 / time.hz as f32))

--- a/game/src/game/attack/mod.rs
+++ b/game/src/game/attack/mod.rs
@@ -135,6 +135,11 @@ impl Attack {
         self.status_mod = Some(modif);
         self
     }
+
+    pub fn with_max_targets(mut self, max_targets: u32) -> Self {
+        self.max_targets = max_targets;
+        self
+    }
 }
 
 /// Event sent when damage is applied

--- a/game/src/game/attack/mod.rs
+++ b/game/src/game/attack/mod.rs
@@ -38,7 +38,7 @@ impl Plugin for AttackPlugin {
                 (
                     determine_attack_targets,
                     apply_attack_modifications,
-                    // DamageInfo event emited here
+                    // DamageInfo event emitted here
                     apply_attack_damage,
                     // OnAttackFirstHitSet
                     track_crits,

--- a/game/src/game/attack/mod.rs
+++ b/game/src/game/attack/mod.rs
@@ -139,6 +139,11 @@ impl Attack {
         self
     }
 
+    pub fn with_damage(mut self, damage: u32) -> Self {
+        self.damage = damage;
+        self
+    }
+
     pub fn with_max_targets(mut self, max_targets: u32) -> Self {
         self.max_targets = max_targets;
         self

--- a/game/src/game/enemy.rs
+++ b/game/src/game/enemy.rs
@@ -228,7 +228,7 @@ fn setup_enemy(
         if !bp.is_added() {
             continue;
         }
-        // TODO: ensure propper z order
+        // TODO: ensure proper z order
         xf_gent.translation.z = 14.0 * 0.000001;
         xf_gent.translation.y += 2.0; // Sprite offset so it looks like it is standing on the ground
         let e_gfx = commands.spawn(()).id();
@@ -547,7 +547,7 @@ struct Decay;
 
 // Check how far the player is, set our range, set our target if applicable, turn to face player if
 // in range
-// TODO: check x and y distance independantly?
+// TODO: check x and y distance independently?
 fn check_player_range(
     mut query: Query<
         (
@@ -795,11 +795,9 @@ fn aggro(
                 transitions.push(Aggroed::new_transition(Patrolling));
             } else if matches!(range, Range::Melee) {
                 match role {
-                    Role::Melee => {
-                        transitions.push(Waiting::new_transition(
-                            MeleeAttack::default(),
-                        ))
-                    },
+                    Role::Melee => transitions.push(Waiting::new_transition(
+                        MeleeAttack::default(),
+                    )),
                     Role::Ranged => {
                         velocity.x = 0.;
                         transitions.push(Waiting::new_transition(
@@ -865,7 +863,7 @@ fn ranged_attack(
             ));
             add_q.add(Idle);
         }
-        // if player isnt alive, do nothing, we will transiton back once animation finishes
+        // if player isnt alive, do nothing, we will transition back once animation finishes
         let Ok(transform) = player_query.get(attack.target) else {
             continue;
         };

--- a/game/src/game/gentstate.rs
+++ b/game/src/game/gentstate.rs
@@ -100,7 +100,7 @@ impl Facing {
 pub trait GentState: Component<Storage = SparseStorage> {}
 
 /// A GenericState has a blanket Transitionable impl for any GentState,
-/// it will remove itsself on transition
+/// it will remove itself on transition
 pub trait GenericState: Component<Storage = SparseStorage> {}
 
 impl<T: GentState, N: GentState + GenericState> Transitionable<T> for N {

--- a/game/src/game/gentstate.rs
+++ b/game/src/game/gentstate.rs
@@ -81,6 +81,14 @@ impl Facing {
             Facing::Left => -1.,
         }
     }
+
+    /// Returns the opposite of a given [`Facing`] variant.
+    pub fn invert(&self) -> Self {
+        match self {
+            Facing::Right => Facing::Left,
+            Facing::Left => Facing::Right,
+        }
+    }
 }
 
 /// States

--- a/game/src/game/player/mod.rs
+++ b/game/src/game/player/mod.rs
@@ -703,6 +703,18 @@ pub struct PlayerConfig {
     /// Ticks for melee knockback velocity; determines how long movement is locked for
     melee_pushback_ticks: u32,
 
+    /// Pushback velocity on basic bow shots
+    bow_self_pushback: f32,
+
+    /// Ticks for bow pushback velocity; determines how long movement is locked for
+    bow_self_pushback_ticks: u32,
+
+    /// Knockback velocity applied to enemy on basic bow hit
+    bow_pushback: f32,
+
+    /// Ticks for melee knockback velocity; determines how long movement is locked for
+    bow_pushback_ticks: u32,
+
     /// Velocity of the projectiles fired by the Bow weapon
     arrow_velocity: f32,
 
@@ -778,6 +790,10 @@ fn update_player_config(config: &mut PlayerConfig, cfg: &DynamicConfig) {
     update_field(&mut errors, &cfg.0, "melee_self_pushback_ticks", |val| config.melee_self_pushback_ticks = val as u32);
     update_field(&mut errors, &cfg.0, "melee_pushback", |val| config.melee_pushback = val);
     update_field(&mut errors, &cfg.0, "melee_pushback_ticks", |val| config.melee_pushback_ticks = val as u32);
+    update_field(&mut errors, &cfg.0, "bow_self_pushback", |val| config.bow_self_pushback = val);
+    update_field(&mut errors, &cfg.0, "bow_self_pushback_ticks", |val| config.bow_self_pushback_ticks = val as u32);
+    update_field(&mut errors, &cfg.0, "bow_pushback", |val| config.bow_pushback = val);
+    update_field(&mut errors, &cfg.0, "bow_pushback_ticks", |val| config.bow_pushback_ticks = val as u32);
     update_field(&mut errors, &cfg.0, "passive_gain_rate", |val| config.passive_gain_rate = val as u32);
     update_field(&mut errors, &cfg.0, "arrow_velocity", |val| config.arrow_velocity = val);
 

--- a/game/src/game/player/mod.rs
+++ b/game/src/game/player/mod.rs
@@ -595,6 +595,13 @@ impl WallSlideTime {
     fn strict_sliding(&self, cfg: &PlayerConfig) -> bool {
         self.0 <= cfg.max_coyote_time * 1.0
     }
+
+    /// Checks that player is actually against the wall, rather then it being close
+    /// enough time from the player having left the wall to still jump
+    /// (ie: not wall_jump_coyote_time)
+    fn is_pressed_against_wall(&self, time: &Res<GameTime>) -> bool {
+        self.0 <= 1.0 / time.hz as f32
+    }
 }
 
 /// Tracks the cooldown for the available energy for the players whirl

--- a/game/src/game/player/mod.rs
+++ b/game/src/game/player/mod.rs
@@ -696,6 +696,9 @@ pub struct PlayerConfig {
     /// Ticks for melee knockback velocity; determines how long movement is locked for
     melee_pushback_ticks: u32,
 
+    /// Velocity of the projectiles fired by the Bow weapon
+    arrow_velocity: f32,
+
     /// How many kills to trigger a passive gain
     passive_gain_rate: u32,
 }
@@ -769,6 +772,7 @@ fn update_player_config(config: &mut PlayerConfig, cfg: &DynamicConfig) {
     update_field(&mut errors, &cfg.0, "melee_pushback", |val| config.melee_pushback = val);
     update_field(&mut errors, &cfg.0, "melee_pushback_ticks", |val| config.melee_pushback_ticks = val as u32);
     update_field(&mut errors, &cfg.0, "passive_gain_rate", |val| config.passive_gain_rate = val as u32);
+    update_field(&mut errors, &cfg.0, "arrow_velocity", |val| config.arrow_velocity = val);
 
     for error in errors{
        warn!("failed to load player cfg value: {}", error);

--- a/game/src/game/player/mod.rs
+++ b/game/src/game/player/mod.rs
@@ -350,7 +350,7 @@ fn setup_player(
                         KeyCode::KeyC,
                     ),
             },
-            // bundling things up becuase we reached max tuple
+            // bundling things up because we reached max tuple
             (
                 Falling,
                 CanDash {
@@ -645,7 +645,7 @@ pub struct PlayerConfig {
     /// How many seconds does our characters innate hover boots work?
     max_coyote_time: f32,
 
-    /// Onlly applies in the downward y direction while the player is falling
+    /// Only applies in the downward y direction while the player is falling
     /// and trying to walk into the wall
     sliding_friction: f32,
 
@@ -801,7 +801,7 @@ pub struct StatusModifier {
 
     /// Multiplying Factor on Stat, e.g. 102.0 * 0.5 = 51.0
     scalar: Vec<f32>,
-    /// Offseting Value on Stat, e.g. 100.0 - 10.0 = 90.0
+    /// Offsetting Value on Stat, e.g. 100.0 - 10.0 = 90.0
     delta: Vec<f32>,
 
     effect_col: Color,

--- a/game/src/game/player/mod.rs
+++ b/game/src/game/player/mod.rs
@@ -703,6 +703,9 @@ pub struct PlayerConfig {
     /// Ticks for melee knockback velocity; determines how long movement is locked for
     melee_pushback_ticks: u32,
 
+    /// Base bow attack damage
+    bow_attack_damage: u32,
+
     /// Pushback velocity on basic bow shots
     bow_self_pushback: f32,
 
@@ -790,6 +793,7 @@ fn update_player_config(config: &mut PlayerConfig, cfg: &DynamicConfig) {
     update_field(&mut errors, &cfg.0, "melee_self_pushback_ticks", |val| config.melee_self_pushback_ticks = val as u32);
     update_field(&mut errors, &cfg.0, "melee_pushback", |val| config.melee_pushback = val);
     update_field(&mut errors, &cfg.0, "melee_pushback_ticks", |val| config.melee_pushback_ticks = val as u32);
+    update_field(&mut errors, &cfg.0, "bow_attack_damage", |val| config.bow_attack_damage = val as u32);
     update_field(&mut errors, &cfg.0, "bow_self_pushback", |val| config.bow_self_pushback = val);
     update_field(&mut errors, &cfg.0, "bow_self_pushback_ticks", |val| config.bow_self_pushback_ticks = val as u32);
     update_field(&mut errors, &cfg.0, "bow_pushback", |val| config.bow_pushback = val);

--- a/game/src/game/player/mod.rs
+++ b/game/src/game/player/mod.rs
@@ -1,5 +1,6 @@
 mod player_anim;
 mod player_behaviour;
+mod player_weapon;
 use bevy::utils::hashbrown::HashMap;
 use leafwing_input_manager::action_state::ActionState;
 use leafwing_input_manager::axislike::VirtualAxis;
@@ -7,6 +8,7 @@ use leafwing_input_manager::input_map::InputMap;
 use leafwing_input_manager::{Actionlike, InputManagerBundle};
 use player_anim::PlayerAnimationPlugin;
 use player_behaviour::PlayerBehaviorPlugin;
+use player_weapon::PlayerWeaponPlugin;
 use rapier2d::geometry::{Group, InteractionGroups};
 use strum::IntoEnumIterator;
 use strum_macros::EnumIter;
@@ -59,6 +61,7 @@ impl Plugin for PlayerPlugin {
             PlayerBehaviorPlugin,
             PlayerTransitionPlugin,
             PlayerAnimationPlugin,
+            PlayerWeaponPlugin,
         ));
 
         #[cfg(feature = "dev")]

--- a/game/src/game/player/player_anim.rs
+++ b/game/src/game/player/player_anim.rs
@@ -238,11 +238,7 @@ fn sprite_flip(
 
             // Have the player face away from the wall if they are attacking while wall sliding
             let pressed_on_wall = wall_slide_time
-                // checks that player is actually against the wall, rather then it being close
-                // enough time from the player having left the wall to still jump
-                // (ie: not wall_jump_coyote_time)
-                .map(|s| s.0 <= 1.0 / time.hz as f32)
-                .unwrap_or(false);
+                .is_some_and(|s| s.is_pressed_against_wall(&time));
             let is_attacking_while_falling =
                 player.current_key() == Some(&weapon.get_anim_key("BasicAir"));
             if pressed_on_wall && is_attacking_while_falling {

--- a/game/src/game/player/player_anim.rs
+++ b/game/src/game/player/player_anim.rs
@@ -16,6 +16,8 @@ use crate::prelude::{
     Res, With, Without,
 };
 
+use super::player_weapon::PlayerWeapon;
+
 /// play animations here, run after transitions
 pub struct PlayerAnimationPlugin;
 
@@ -152,10 +154,11 @@ fn player_attacking_animation(
             Option<&HitFreezeTime>,
             Ref<Attacking>,
         ),
-        (Without<Whirling>),
+        Without<Whirling>,
     >,
     mut gfx_query: Query<&mut ScriptPlayer<SpriteAnimation>, With<PlayerGfx>>,
     config: Res<PlayerConfig>,
+    weapon: Res<PlayerWeapon>,
 ) {
     for (gent, is_falling, is_jumping, is_running, hitfrozen, attacking) in
         query.iter()
@@ -166,31 +169,29 @@ fn player_attacking_animation(
                 .unwrap_or(false);
             // let current = player.current_key().unwrap_or("").clone();
             player.set_slot("AttackTransition", false);
+            let basic_air_anim_key_str = &weapon.get_anim_key("BasicAir");
+            let basic_run_anim_key_str = &weapon.get_anim_key("BasicRun");
+            let basic_idle_anim_key_str = &weapon.get_anim_key("BasicIdle");
+
             if is_falling || is_jumping {
                 // TODO: These need a way to resume the new animation from the current frame index
                 // or specified offset
-                if player.current_key().unwrap_or("")
-                    != "anim.player.SwordBasicAir"
-                {
-                    player.play_key("anim.player.SwordBasicAir");
+                if player.current_key() != Some(basic_air_anim_key_str) {
+                    player.play_key(basic_air_anim_key_str);
                     if !attacking.is_added() {
                         player.set_slot("AttackTransition", true);
                     }
                 }
             } else if is_running && !hitfrozen {
-                if player.current_key().unwrap_or("")
-                    != "anim.player.SwordBasicRun"
-                {
-                    player.play_key("anim.player.SwordBasicRun");
+                if player.current_key() != Some(basic_run_anim_key_str) {
+                    player.play_key(basic_run_anim_key_str);
                     if !attacking.is_added() {
                         player.set_slot("AttackTransition", true);
                     }
                 }
             } else {
-                if player.current_key().unwrap_or("")
-                    != "anim.player.SwordBasicIdle"
-                {
-                    player.play_key("anim.player.SwordBasicIdle");
+                if player.current_key() != Some(basic_idle_anim_key_str) {
+                    player.play_key(basic_idle_anim_key_str);
                     if !attacking.is_added() {
                         player.set_slot("AttackTransition", true);
                     }
@@ -228,6 +229,7 @@ fn sprite_flip(
     mut current_direction: Local<bool>,
     mut old_direction: Local<bool>,
     time: Res<GameTime>,
+    weapon: Res<PlayerWeapon>,
 ) {
     for (facing, gent, wall_slide_time) in query.iter() {
         if let Ok(mut player) = gfx_query.get_mut(gent.e_gfx) {
@@ -241,9 +243,9 @@ fn sprite_flip(
                 // (ie: not wall_jump_coyote_time)
                 .map(|s| s.0 <= 1.0 / time.hz as f32)
                 .unwrap_or(false);
-            if pressed_on_wall
-                && player.current_key() == Some("anim.player.SwordBasicAir")
-            {
+            let is_attacking_while_falling =
+                player.current_key() == Some(&weapon.get_anim_key("BasicAir"));
+            if pressed_on_wall && is_attacking_while_falling {
                 facing = match facing {
                     Facing::Right => Facing::Left,
                     Facing::Left => Facing::Right,

--- a/game/src/game/player/player_behaviour.rs
+++ b/game/src/game/player/player_behaviour.rs
@@ -1023,7 +1023,7 @@ fn player_attack(
                             Projectile { vel },
                             Collider::cuboid(
                                 12.0,
-                                12.0,
+                                3.0,
                                 InteractionGroups::new(
                                     PLAYER_ATTACK,
                                     ENEMY_HURT | GROUND,

--- a/game/src/game/player/player_behaviour.rs
+++ b/game/src/game/player/player_behaviour.rs
@@ -980,6 +980,7 @@ fn player_attack(
             &Gent,
             &Facing,
             &Transform,
+            Option<&WallSlideTime>,
             &mut Attacking,
             &mut TransitionQueue,
             &ActionState<PlayerAction>,
@@ -990,12 +991,14 @@ fn player_attack(
     mut commands: Commands,
     config: Res<PlayerConfig>,
     weapon: Res<PlayerWeapon>,
+    time: Res<GameTime>,
 ) {
     for (
         entity,
         gent,
         facing,
         transform,
+        wall_slide_time,
         mut attacking,
         mut transitions,
         action_state,
@@ -1010,8 +1013,15 @@ fn player_attack(
                     animation.play_key("anim.player.BowBasicArrow");
                     animation.set_slot("Start", true);
 
+                    let is_player_pressed_against_wall = wall_slide_time
+                        .is_some_and(|s| s.is_pressed_against_wall(&time));
+                    let arrow_direction = if is_player_pressed_against_wall {
+                        -facing.direction()
+                    } else {
+                        facing.direction()
+                    };
                     let vel = LinearVelocity(
-                        Vec2::X * facing.direction() * config.arrow_velocity,
+                        Vec2::X * arrow_direction * config.arrow_velocity,
                     );
 
                     commands

--- a/game/src/game/player/player_behaviour.rs
+++ b/game/src/game/player/player_behaviour.rs
@@ -13,7 +13,7 @@ use theseeker_engine::physics::{
 };
 use theseeker_engine::script::ScriptPlayer;
 
-use super::arc_attack::Projectile;
+use super::arc_attack::{Arrow, Projectile};
 use super::player_weapon::PlayerWeapon;
 use super::{
     dash_icon_fx, player_dash_fx, player_new_stats_mod, AttackBundle,
@@ -1026,6 +1026,7 @@ fn player_attack(
 
                     commands
                         .spawn((
+                            Arrow,
                             SpriteSheetBundle {
                                 transform: *transform,
                                 ..Default::default()

--- a/game/src/game/player/player_behaviour.rs
+++ b/game/src/game/player/player_behaviour.rs
@@ -1043,7 +1043,9 @@ fn player_attack(
                                     ENEMY_HURT | GROUND,
                                 ),
                             ),
-                            Attack::new(192, entity).with_max_targets(1),
+                            Attack::new(192, entity)
+                                .with_damage(config.bow_attack_damage)
+                                .with_max_targets(1),
                             Pushback(Knockback::new(
                                 Vec2::new(
                                     facing.direction() * config.bow_pushback,

--- a/game/src/game/player/player_behaviour.rs
+++ b/game/src/game/player/player_behaviour.rs
@@ -1027,6 +1027,16 @@ fn player_attack(
                         Vec2::X * arrow_direction * config.arrow_velocity,
                     );
 
+                    if !is_player_pressed_against_wall {
+                        commands.entity(entity).insert(Knockback::new(
+                            Vec2::new(
+                                -facing.direction() * config.bow_self_pushback,
+                                0.,
+                            ),
+                            config.bow_self_pushback_ticks,
+                        ));
+                    }
+
                     commands
                         .spawn((
                             Arrow,

--- a/game/src/game/player/player_behaviour.rs
+++ b/game/src/game/player/player_behaviour.rs
@@ -1029,7 +1029,7 @@ fn player_attack(
                                     ENEMY_HURT | GROUND,
                                 ),
                             ),
-                            Attack::new(16, entity).with_max_targets(1),
+                            Attack::new(192, entity).with_max_targets(1),
                             Pushback(Knockback::new(
                                 Vec2::new(
                                     facing.direction() * config.melee_pushback,

--- a/game/src/game/player/player_behaviour.rs
+++ b/game/src/game/player/player_behaviour.rs
@@ -1046,10 +1046,10 @@ fn player_attack(
                             Attack::new(192, entity).with_max_targets(1),
                             Pushback(Knockback::new(
                                 Vec2::new(
-                                    facing.direction() * config.melee_pushback,
+                                    facing.direction() * config.bow_pushback,
                                     0.,
                                 ),
-                                config.melee_pushback_ticks,
+                                config.bow_pushback_ticks,
                             )),
                             animation,
                             StateDespawnMarker,

--- a/game/src/game/player/player_behaviour.rs
+++ b/game/src/game/player/player_behaviour.rs
@@ -581,7 +581,7 @@ pub fn player_collisions(
                             if dashing.is_none() && whirling.is_none() {
                                 let sliding_plane =
                                     into_vec2(first_hit.normal1);
-                                // configurable theshold for collision normal/sliding plane in case of physics instability
+                                // configurable threshold for collision normal/sliding plane in case of physics instability
                                 let threshold = 0.000001;
                                 if !(1. - threshold..=1. + threshold)
                                     .contains(&sliding_plane.y)
@@ -634,7 +634,7 @@ pub fn player_collisions(
                             let friction_force = if projected_velocity.y < -0.0
                             {
                                 // make sure at least 1/2 of player is against the wall
-                                // (because it looks wierd to have the character hanging by their head)
+                                // (because it looks weird to have the character hanging by their head)
                                 if spatial_query
                                     .ray_cast(
                                         pos.translation.xy(),

--- a/game/src/game/player/player_weapon.rs
+++ b/game/src/game/player/player_weapon.rs
@@ -1,4 +1,5 @@
 use bevy::app::Update;
+use bevy::prelude::Res;
 use leafwing_input_manager::prelude::ActionState;
 use strum_macros::Display;
 
@@ -40,4 +41,9 @@ fn swap_weapon(
             };
         }
     }
+}
+
+/// Run condition that checks if the Player is using the Bow
+pub fn is_player_using_bow(weapon: Res<PlayerWeapon>) -> bool {
+    weapon.eq(&PlayerWeapon::Bow)
 }

--- a/game/src/game/player/player_weapon.rs
+++ b/game/src/game/player/player_weapon.rs
@@ -1,0 +1,36 @@
+use leafwing_input_manager::prelude::ActionState;
+
+use crate::game::player::{Player, PlayerAction};
+use crate::prelude::{
+    App, GameTickUpdate, Plugin, Query, ResMut, Resource, With,
+};
+
+pub(crate) struct PlayerWeaponPlugin;
+
+impl Plugin for PlayerWeaponPlugin {
+    fn build(&self, app: &mut App) {
+        app.insert_resource(PlayerWeapon::default());
+        app.add_systems(GameTickUpdate, swap_weapon);
+    }
+}
+
+#[derive(Resource, Default, PartialEq, Eq)]
+pub enum PlayerWeapon {
+    Bow,
+    #[default]
+    Sword,
+}
+
+fn swap_weapon(
+    mut weapon: ResMut<PlayerWeapon>,
+    query: Query<&ActionState<PlayerAction>, With<Player>>,
+) {
+    for action_state in &query {
+        if action_state.just_pressed(&PlayerAction::SwapWeapon) {
+            *weapon = match *weapon {
+                PlayerWeapon::Bow => PlayerWeapon::Sword,
+                PlayerWeapon::Sword => PlayerWeapon::Bow,
+            };
+        }
+    }
+}

--- a/game/src/game/player/player_weapon.rs
+++ b/game/src/game/player/player_weapon.rs
@@ -1,4 +1,5 @@
 use leafwing_input_manager::prelude::ActionState;
+use strum_macros::Display;
 
 use crate::game::player::{Player, PlayerAction};
 use crate::prelude::{
@@ -14,11 +15,18 @@ impl Plugin for PlayerWeaponPlugin {
     }
 }
 
-#[derive(Resource, Default, PartialEq, Eq)]
+#[derive(Resource, Default, PartialEq, Eq, Display)]
 pub enum PlayerWeapon {
     Bow,
     #[default]
     Sword,
+}
+
+impl PlayerWeapon {
+    pub fn get_anim_key(&self, action: &str) -> String {
+        let weapon_str = self.to_string();
+        format!("anim.player.{weapon_str}{action}")
+    }
 }
 
 fn swap_weapon(

--- a/game/src/game/player/player_weapon.rs
+++ b/game/src/game/player/player_weapon.rs
@@ -1,17 +1,16 @@
+use bevy::app::Update;
 use leafwing_input_manager::prelude::ActionState;
 use strum_macros::Display;
 
 use crate::game::player::{Player, PlayerAction};
-use crate::prelude::{
-    App, GameTickUpdate, Plugin, Query, ResMut, Resource, With,
-};
+use crate::prelude::{App, Plugin, Query, ResMut, Resource, With};
 
 pub(crate) struct PlayerWeaponPlugin;
 
 impl Plugin for PlayerWeaponPlugin {
     fn build(&self, app: &mut App) {
         app.insert_resource(PlayerWeapon::default());
-        app.add_systems(GameTickUpdate, swap_weapon);
+        app.add_systems(Update, swap_weapon);
     }
 }
 


### PR DESCRIPTION
Fixes #137

- Added `PlayerWeapon` plugin that manages swapping between the Sword and the Bow weapons.
- Added a new keybind (H key) that swaps weapons for the Player.
- While using the Bow weapon, the Player now shoots arrows when pressing the attack key.
- Player will always face an enemy when holding the Bow weapon.
- Added configurable velocity, knockback and base damage variables for the arrows shot by the Player.
- FIxed a few typos in comments.