### PR TITLE
Add downward dash ability

### DIFF
--- a/assets/animations.assets.ron
+++ b/assets/animations.assets.ron
@@ -169,6 +169,18 @@
         rows: 1,
         columns: 6,
     ),
+    "anim.player.SwordDashDownStrike": File (
+        path: "animations/player/sword/DashDownStrike.anim.toml",
+    ),
+    "anim.player.SwordDashDownStrike.image": File (
+        path: "animations/player/sword/DashDownSheet.png",
+    ),
+    "anim.player.SwordDashDownStrike.atlas": TextureAtlasLayout (
+        tile_size_x: 48.,
+        tile_size_y: 48.,
+        rows: 1,
+        columns: 6,
+    ),
     "anim.player.BowBasicIdle": File (
         path: "animations/player/bow/BasicIdle.anim.toml",
     ),

--- a/assets/animations/player/sword/DashDownStrike.anim.toml
+++ b/assets/animations/player/sword/DashDownStrike.anim.toml
@@ -4,10 +4,9 @@ tick_quant = "8"
 ticks_per_frame = 8
 frame_min = 1
 frame_max = 6
-frame_start = 1
+frame_start = 5
 
-# LOOP
 [[script]]
-run_at_frame = 4
-action = "SetFrameNext"
-frame_index = 2
+run_at_frame = [5]
+action = "PlayAudio"
+asset_key = "audio.game.HammerImpact"

--- a/assets/player.cfg.toml
+++ b/assets/player.cfg.toml
@@ -43,6 +43,9 @@ hitfreeze_ticks = 45.0
 # How many seconds does our character dash for?
 dash_duration = 0.06
 
+# How many seconds does our character dash for?
+dash_down_duration = 0.1
+
 # How many seconds does our character stealth for?
 stealth_duration = 2.0
 
@@ -52,8 +55,17 @@ stealth_cooldown = 5.0
 # How many pixels/s do they dash with?
 dash_velocity = 400.0
 
+# How many pixels/s do they dash down with, horizontally?
+dash_down_horizontal_velocity = 250.0
+
+# How many pixels/s do they dash down with, vertically?
+dash_down_vertical_velocity = 250.0
+
 # How long before the player can dash again?
 dash_cooldown_duration = 1.0
+
+# How long before the player can dash again?
+dash_down_cooldown_duration = 1.5
 
 max_whirl_energy = 5.0
 

--- a/game/src/game/player/mod.rs
+++ b/game/src/game/player/mod.rs
@@ -521,6 +521,7 @@ impl Default for DashType {
 pub struct Dashing {
     duration: f32,
     hit: bool,
+    hit_ground: bool,
     dash_type: DashType,
 }
 impl Dashing {

--- a/game/src/game/player/mod.rs
+++ b/game/src/game/player/mod.rs
@@ -8,6 +8,7 @@ use leafwing_input_manager::{Actionlike, InputManagerBundle};
 use player_anim::PlayerAnimationPlugin;
 use player_behaviour::PlayerBehaviorPlugin;
 use rapier2d::geometry::{Group, InteractionGroups};
+use rapier2d::na::Vector3;
 use strum::IntoEnumIterator;
 use strum_macros::EnumIter;
 use theseeker_engine::animation::SpriteAnimationBundle;
@@ -121,6 +122,7 @@ pub enum PlayerAction {
     Dash,
     Whirl,
     Stealth,
+    Fall,
 }
 
 #[derive(Component, Debug, Deref, DerefMut)]
@@ -181,6 +183,7 @@ fn debug_player_states(
             Ref<Jumping>,
             Ref<Grounded>,
             Ref<Dashing>,
+            Ref<DashStrike>,
             Ref<CanDash>,
         )>,
         With<Player>,
@@ -188,8 +191,16 @@ fn debug_player_states(
 ) {
     for states in query.iter() {
         // println!("{:?}", states);
-        let (running, idle, falling, jumping, grounded, dashing, can_dash) =
-            states;
+        let (
+            running,
+            idle,
+            falling,
+            jumping,
+            grounded,
+            dashing,
+            dash_strike,
+            can_dash,
+        ) = states;
         let mut states_string: String = String::new();
         if let Some(running) = running {
             if running.is_added() {
@@ -218,7 +229,16 @@ fn debug_player_states(
         }
         if let Some(dashing) = dashing {
             if dashing.is_added() {
-                states_string.push_str("added dashing, ");
+                if dashing.is_down_dash() {
+                    states_string.push_str("added down dashing, ");
+                } else {
+                    states_string.push_str("added dashing, ");
+                }
+            }
+        }
+        if let Some(dash_strike) = dash_strike {
+            if dash_strike.is_added() {
+                states_string.push_str("added dashing strike ");
             }
         }
         if let Some(can_dash) = can_dash {
@@ -311,6 +331,8 @@ fn setup_player(
                     .with(PlayerAction::Jump, KeyCode::Space)
                     .with(PlayerAction::Jump, KeyCode::KeyW)
                     .with(PlayerAction::Jump, KeyCode::ArrowUp)
+                    .with(PlayerAction::Fall, KeyCode::ArrowDown)
+                    .with(PlayerAction::Fall, KeyCode::KeyS)
                     .with(
                         PlayerAction::Move,
                         VirtualAxis::from_keys(KeyCode::KeyA, KeyCode::KeyD),
@@ -333,6 +355,7 @@ fn setup_player(
                 Falling,
                 CanDash {
                     remaining_cooldown: 0.0,
+                    total_cooldown: 0.0,
                 },
                 CanStealth {
                     remaining_cooldown: 0.0,
@@ -480,10 +503,76 @@ impl Whirling {
     const MIN_TICKS: u32 = 48;
 }
 
+/// Differentiates between different types of dashing
+//#[allow(clippy::enum_variant_names)]
+#[derive(Clone, Copy, Eq, PartialEq, Hash, Debug)]
+pub enum DashType {
+    Horizontal,
+    Downward,
+}
+impl Default for DashType {
+    fn default() -> Self {
+        return DashType::Horizontal;
+    }
+}
+
 #[derive(Component, Debug, Default)]
 #[component(storage = "SparseSet")]
 pub struct Dashing {
     duration: f32,
+    hit: bool,
+    dash_type: DashType,
+}
+impl Dashing {
+    pub fn from_action_state(action_state: &ActionState<PlayerAction>) -> Self {
+        if action_state.pressed(&PlayerAction::Fall) {
+            println!("dashing down!");
+            return Self {
+                dash_type: DashType::Downward,
+                ..default()
+            };
+        } else {
+            println!("dashing horizontally!");
+            return Self {
+                dash_type: DashType::Horizontal,
+                ..default()
+            };
+        }
+    }
+
+    pub fn dash_duration(&self, config: &PlayerConfig) -> f32 {
+        return match self.dash_type {
+            DashType::Horizontal => config.dash_duration,
+            DashType::Downward => config.dash_down_duration,
+        };
+    }
+
+    pub fn is_down_dash(&self) -> bool {
+        return self.dash_type == DashType::Downward;
+    }
+
+    pub fn is_horizontal_dash(&self) -> bool {
+        return self.dash_type == DashType::Horizontal;
+    }
+
+    pub fn set_player_velocity(
+        &self,
+        velocity: &mut LinearVelocity,
+        facing: &Facing,
+        config: &PlayerConfig,
+    ) {
+        match self.dash_type {
+            DashType::Horizontal => {
+                velocity.x = config.dash_velocity * facing.direction();
+                velocity.y = 0.0;
+            },
+            DashType::Downward => {
+                velocity.x =
+                    config.dash_down_horizontal_velocity * facing.direction();
+                velocity.y = -config.dash_down_vertical_velocity;
+            },
+        };
+    }
 }
 
 impl GentState for Dashing {}
@@ -491,15 +580,41 @@ impl Transitionable<CanDash> for Dashing {
     type Removals = (Dashing, Whirling);
 }
 
+impl Transitionable<DashStrike> for Dashing {
+    type Removals = (Dashing, Whirling);
+}
+
+#[derive(Component, Debug, Default)]
+#[component(storage = "SparseSet")]
+pub struct DashStrike {
+    ticks: u32,
+}
+
+impl DashStrike {
+    pub const MAX: u32 = 2;
+}
+
+impl GentState for DashStrike {}
+impl Transitionable<CanDash> for DashStrike {
+    type Removals = (DashStrike, Whirling, Dashing);
+}
+
 #[derive(Component, Debug)]
 #[component(storage = "SparseSet")]
 pub struct CanDash {
     pub remaining_cooldown: f32,
+    pub total_cooldown: f32,
 }
 impl CanDash {
-    pub fn new(config: &PlayerConfig) -> Self {
+    pub fn new(config: &PlayerConfig, dash_type: &DashType) -> Self {
+        let cooldown = match dash_type {
+            DashType::Horizontal => config.dash_cooldown_duration,
+            DashType::Downward => config.dash_down_cooldown_duration,
+        };
+
         Self {
-            remaining_cooldown: config.dash_cooldown_duration,
+            remaining_cooldown: cooldown,
+            total_cooldown: cooldown,
         }
     }
 }
@@ -633,6 +748,9 @@ pub struct PlayerConfig {
     /// How many seconds does our character dash for?
     dash_duration: f32,
 
+    /// How many seconds does our character dash for?
+    dash_down_duration: f32,
+
     /// How many seconds does our character stealth for?
     stealth_duration: f32,
 
@@ -642,8 +760,17 @@ pub struct PlayerConfig {
     /// How many pixels/s do they dash with?
     dash_velocity: f32,
 
+    /// How many pixels/s (horizontally) do they dash with when doing a downward dash?
+    dash_down_horizontal_velocity: f32,
+
+    /// How many pixels/s (vertically) do they dash with when doing a downward dash?
+    dash_down_vertical_velocity: f32,
+
     /// How long before the player can dash again?
     pub dash_cooldown_duration: f32,
+
+    /// How long before the player can dash again?
+    pub dash_down_cooldown_duration: f32,
 
     pub max_whirl_energy: f32,
 
@@ -720,7 +847,6 @@ fn load_player_config(
 #[rustfmt::skip]
 fn update_player_config(config: &mut PlayerConfig, cfg: &DynamicConfig) {
     let mut errors = Vec::new();
-
     update_field(&mut errors, &cfg.0, "max_move_vel", |val| config.max_move_vel = val);
     update_field(&mut errors, &cfg.0, "max_fall_vel", |val| config.max_fall_vel = val);
     update_field(&mut errors, &cfg.0, "move_accel_init", |val| config.move_accel_init = val);
@@ -732,8 +858,12 @@ fn update_player_config(config: &mut PlayerConfig, cfg: &DynamicConfig) {
     update_field(&mut errors, &cfg.0, "sliding_friction", |val| config.sliding_friction = val);
     update_field(&mut errors, &cfg.0, "hitfreeze_ticks", |val| config.hitfreeze_ticks = val as u32);
     update_field(&mut errors, &cfg.0, "dash_duration", |val| config.dash_duration = val);
+    update_field(&mut errors, &cfg.0, "dash_down_duration", |val| config.dash_down_duration = val);
     update_field(&mut errors, &cfg.0, "dash_velocity", |val| config.dash_velocity = val);
+    update_field(&mut errors, &cfg.0, "dash_down_horizontal_velocity", |val| config.dash_down_horizontal_velocity = val);
+    update_field(&mut errors, &cfg.0, "dash_down_vertical_velocity", |val| config.dash_down_vertical_velocity = val);
     update_field(&mut errors, &cfg.0, "dash_cooldown_duration", |val| config.dash_cooldown_duration = val);
+    update_field(&mut errors, &cfg.0, "dash_down_cooldown_duration", |val| config.dash_down_cooldown_duration = val);
     update_field(&mut errors, &cfg.0, "stealth_duration", |val| config.stealth_duration = val);
     update_field(&mut errors, &cfg.0, "stealth_cooldown", |val| config.stealth_cooldown = val);
     update_field(&mut errors, &cfg.0, "max_whirl_energy", |val| config.max_whirl_energy = val);
@@ -902,15 +1032,52 @@ fn player_new_stats_mod(
 pub struct DashIcon {
     time: f32,
     init_a: f32,
+    dash_duration: f32,
 }
 
 #[derive(Resource)]
-pub struct DashIconAssetHandle(Handle<Image>);
+pub struct DashIconAssetHandle {
+    tex: Handle<Image>,
+    atlas: TextureAtlas,
+}
+#[derive(Resource)]
+pub struct DashDownIconAssetHandle {
+    tex: Handle<Image>,
+    atlas: TextureAtlas,
+}
 
-pub fn load_dash_asset(assets: Res<AssetServer>, mut commands: Commands) {
-    let tex: Handle<Image> = assets.load("animations/player/movement/Dash.png");
+pub fn load_dash_asset(
+    assets: Res<AssetServer>,
+    mut texture_atlas_layouts: ResMut<Assets<TextureAtlasLayout>>,
+    mut commands: Commands,
+) {
+    let dash_tex: Handle<Image> =
+        assets.load("animations/player/movement/Dash.png");
+    let dash_layout =
+        TextureAtlasLayout::from_grid(Vec2::new(96.0, 96.0), 1, 1, None, None);
+    let dash_layout_handle = texture_atlas_layouts.add(dash_layout);
 
-    commands.insert_resource(DashIconAssetHandle(tex));
+    let dash_down_tex: Handle<Image> =
+        assets.load("animations/player/sword/DashDownSheet.png");
+    let dash_down_layout =
+        TextureAtlasLayout::from_grid(Vec2::new(48.0, 48.0), 6, 1, None, None);
+    let dash_down_layout_handle = texture_atlas_layouts.add(dash_down_layout);
+
+    commands.insert_resource(DashIconAssetHandle {
+        tex: dash_tex,
+        atlas: TextureAtlas {
+            layout: dash_layout_handle,
+            index: 0,
+        },
+    });
+
+    commands.insert_resource(DashDownIconAssetHandle {
+        tex: dash_down_tex,
+        atlas: TextureAtlas {
+            layout: dash_down_layout_handle,
+            index: 1,
+        },
+    });
 }
 
 pub fn player_dash_fx(
@@ -919,7 +1086,7 @@ pub fn player_dash_fx(
             &GlobalTransform,
             &Facing,
             //            &LinearVelocity,
-            Ref<Dashing>,
+            &Dashing,
             Option<&Stealthing>,
         ),
         With<Player>,
@@ -927,49 +1094,48 @@ pub fn player_dash_fx(
     config: Res<PlayerConfig>,
     time: Res<GameTime>,
     mut commands: Commands,
-    asset: Res<DashIconAssetHandle>,
+    dash_asset: Res<DashIconAssetHandle>,
+    dash_down_asset: Res<DashDownIconAssetHandle>,
 ) {
-    for (global_tr, facing, _dashing, stealthing_maybe) in query.iter() {
+    for (global_tr, facing, dashing, stealthing_maybe) in query.iter() {
         let pos = global_tr.translation();
 
-        // Code for potentially interpolating position
-        // Not deemed necessary due to sufficient sprite overlap
-        // let dir = Vec3::new(
-        //    config.dash_velocity * facing.direction(),
-        //    0.0,
-        //    0.0,
-        //);
-        // let lpos = pos + dir * 0.5;
-        // if dashing.is_added() {
-        //
-        //} else
-        {
-            // let dir = Vec2::new(
-            //    config.dash_velocity * facing.direction(),
-            //    0.0,
-            //);
+        let t = time.time_in_seconds() as f32 + dashing.dash_duration(&config);
 
-            let tex: Handle<Image> = asset.0.clone();
-            let t = time.time_in_seconds() as f32 + config.dash_duration;
+        let init_a = match stealthing_maybe {
+            Some(_) => 0.2,
+            None => 0.5,
+        };
 
-            let init_a = match stealthing_maybe {
-                Some(_) => 0.2,
-                None => 0.5,
-            };
+        let (tex, atlas) = if dashing.is_down_dash() {
+            (
+                dash_down_asset.tex.clone(),
+                dash_down_asset.atlas.clone(),
+            )
+        } else {
+            (
+                dash_asset.tex.clone(),
+                dash_asset.atlas.clone(),
+            )
+        };
 
-            commands.spawn((
-                SpriteBundle {
-                    sprite: Sprite {
-                        flip_x: facing.direction() < 0.,
-                        ..default()
-                    },
-                    transform: Transform::from_translation(pos),
-                    texture: tex.clone(),
+        commands.spawn((
+            SpriteSheetBundle {
+                sprite: Sprite {
+                    flip_x: facing.direction() < 0.,
                     ..default()
                 },
-                DashIcon { time: t, init_a },
-            ));
-        }
+                transform: Transform::from_translation(pos),
+                texture: tex.clone(),
+                atlas,
+                ..default()
+            },
+            DashIcon {
+                time: t,
+                init_a,
+                dash_duration: dashing.dash_duration(&config),
+            },
+        ));
     }
 }
 
@@ -982,7 +1148,7 @@ pub fn dash_icon_fx(
     for (entity, icon, mut sprite) in query.iter_mut() {
         let d = time.time_in_seconds() as f32 - icon.time;
 
-        let r = d / config.dash_duration;
+        let r = d / icon.dash_duration;
 
         if r >= 1.0 {
             commands.entity(entity).despawn();

--- a/game/src/game/player/player_anim.rs
+++ b/game/src/game/player/player_anim.rs
@@ -1,10 +1,11 @@
-use bevy::prelude::{DetectChanges, Ref};
+use bevy::prelude::{DetectChanges, Ref, RemovedComponents};
 use theseeker_engine::assets::animation::SpriteAnimation;
 use theseeker_engine::gent::Gent;
 use theseeker_engine::physics::LinearVelocity;
 use theseeker_engine::prelude::{GameTickUpdate, GameTime};
 use theseeker_engine::script::ScriptPlayer;
 
+use super::DashStrike;
 use crate::appstate::AppState;
 use crate::game::gentstate::Facing;
 use crate::game::player::{
@@ -31,6 +32,7 @@ impl Plugin for PlayerAnimationPlugin {
                 player_attacking_animation,
                 player_whirling_animation,
                 player_dashing_animation,
+                player_dashing_strike_animation,
                 sprite_flip.after(player_dashing_animation),
             )
                 .in_set(PlayerStateSet::Animation)
@@ -212,12 +214,27 @@ fn player_whirling_animation(
 }
 
 fn player_dashing_animation(
-    query: Query<&Gent, Added<Dashing>>,
+    query: Query<(&Gent, &Dashing), Added<Dashing>>,
     mut gfx_query: Query<&mut ScriptPlayer<SpriteAnimation>, With<PlayerGfx>>,
 ) {
-    for gent in query.iter() {
+    for (gent, dashing) in query.iter() {
         if let Ok(mut player) = gfx_query.get_mut(gent.e_gfx) {
-            player.play_key("anim.player.Dash")
+            if dashing.is_down_dash() {
+                player.play_key("anim.player.SwordDashDown")
+            } else {
+                player.play_key("anim.player.Dash")
+            }
+        }
+    }
+}
+
+fn player_dashing_strike_animation(
+    query: Query<(&Gent, &DashStrike), Added<DashStrike>>,
+    mut gfx_query: Query<&mut ScriptPlayer<SpriteAnimation>, With<PlayerGfx>>,
+) {
+    for (gent, _dash_strike) in query.iter() {
+        if let Ok(mut player) = gfx_query.get_mut(gent.e_gfx) {
+            player.play_key("anim.player.SwordDashDownStrike")
         }
     }
 }

--- a/game/src/game/player/player_behaviour.rs
+++ b/game/src/game/player/player_behaviour.rs
@@ -720,11 +720,14 @@ pub fn player_collisions(
                             // If we are dashing downwards, immediately cancel the dash, shake the camera, and start the attack animation, but don't do anything else.
                             if let Some(mut dashing) = dashing.as_mut() {
                                 if dashing.is_down_dash() {
-                                    trigger_dash_strike(
-                                        &mut commands,
-                                        dashing,
-                                        false,
-                                    );
+                                    // currently, this feels out of place, as the strike stops just short of the ground.
+                                    // we currently do not have any flying enemies, so disabling dash strikes for enemies.
+
+                                    // trigger_dash_strike(
+                                    //     &mut commands,
+                                    //     dashing,
+                                    //     false,
+                                    // );
                                 }
                             }
 

--- a/game/src/game/player/player_behaviour.rs
+++ b/game/src/game/player/player_behaviour.rs
@@ -48,10 +48,12 @@ impl Plugin for PlayerBehaviorPlugin {
         app.add_systems(
             GameTickUpdate,
             (
-                (gain_passives.run_if(resource_changed::<KillCount>)),
+                (
+                    gain_passives.run_if(resource_changed::<KillCount>),
+                    player_new_stats_mod,
+                ),
                 (
                     player_idle.run_if(any_with_component::<Idle>),
-                    player_new_stats_mod,
                     add_attack,
                     player_stealth,
                     player_whirl_charge.before(player_whirl),

--- a/game/src/ui/skill_toolbar.rs
+++ b/game/src/ui/skill_toolbar.rs
@@ -254,8 +254,7 @@ fn update_dash_ability_ui(
         return;
     };
     for entity in ui.iter() {
-        let factor =
-            can_dash.remaining_cooldown / config.dash_cooldown_duration;
+        let factor = can_dash.remaining_cooldown / can_dash.total_cooldown;
         commands.entity(entity).factor(factor);
     }
 }


### PR DESCRIPTION
addresses #125 

Adds a downward dash ability when pressing the 's' key when activating a dash.

The downward dash uses a different animation.

When colliding with an enemy or a wall, a strike animation is played, as well as a damage collider. The camera also shakes on impact.

If there is no collision, there is no final strike animation, and no damage collider.

The main changes involved adding new fields to the "Dashing" state's struct to keep track of what type of dash is happening, and adding a new "DashStrike" state to handle the strike attack state. Throughout the code, there are several references that assumed the configuration values for a dash were constant. These changed to use the dash's type to either use the "horizontal" dash config, or the "downward" dash config. 

The animation scripts were modified to add a new "SwordDashDownStrike" animation, rather than put it in the same "SwordDashDown" animation. I felt it made more sense to simply queue up a new animation from rust when a collision happens, rather than use and keep track of a "slot" to let the script make that logic. Both animations use the same sprite sheet image file.

The "DashStrike" state works almost exactly the same as the "Attack" state, keeping track of the number of ticks elapsed, and transitioning after a "maximum" ticks has passed. I don't love this approach, mainly because the "maximum" ticks seems to be decoupled from the animation files. I also had to "guess" at what ticks the actual damage dots appear in the animation, which if the animation changes, the damage colliders will not appear, or not appear at the right time. It would be nice if we there was a way I could put that info in the script/animation file somewhere, and just query it in the rust code (like, `scriptplayer.has_damage_dots()` or `scriptplayer.read_data("hit_frame") == true` so I could just wait until the first tick with damage dots... which evidently is not the first 8 or so ticks xD

To start the DashStrike, in the player_collision system, if there is a collision the `Dashing` object's "hit" field is set to true, and it's duration set to max, the same way the dashes are canceled when the player runs into a wall. This is also where the camera shake happens. This causes the player_dash system to gracefully exit the dash state on the next tick. If there was a 'hit', it transitions to the `DashStrike` state, otherwise it transitions to the `CanDash` state, with the various `CanAttack`, `Grounded`, etc.. the "default idle" state if you will.

In order to have different cooldowns, the `CanDash` struct now keeps track of the cooldown, since the ui will need to know how much longer to wait, but also what the original cooldown was, in order to show a nice progress bar. Without the original `Dashing` object, there would be no way to know what sort of dash it was, and how long the cooldown started.

