### PR TITLE
Change Vignette color on Low HP

### DIFF
--- a/game/src/graphics/player_hp.rs
+++ b/game/src/graphics/player_hp.rs
@@ -6,12 +6,14 @@ use crate::game::attack::Health;
 use crate::game::player::Player;
 use crate::prelude::Update;
 
+use super::post_processing::vignette::VignetteSettings;
+
 pub struct PlayerHpBarPlugin;
 
 impl Plugin for PlayerHpBarPlugin {
     fn build(&self, app: &mut App) {
         app.add_plugins(UiMaterialPlugin::<Material>::default());
-        app.add_systems(Update, update_hp);
+        app.add_systems(Update, (update_hp, update_hp_vignette));
     }
 }
 
@@ -51,4 +53,40 @@ fn update_hp(
             }
         }
     }
+}
+
+fn update_hp_vignette(
+    player_q: Query<&Health, With<Player>>,
+    time: Res<Time>,
+    mut query: Query<&mut VignetteSettings>, 
+) {
+    if let Ok(health) = player_q.get_single() {
+        let health_percentage = health.current as f32 / health.max as f32;
+        if health_percentage <= 0.25 {
+            let bpm = 103.0;
+            let frequency = bpm / 60.0; // Convert BPM to Hz
+            let elapsed = time.elapsed_seconds(); 
+            let time_cos = (elapsed * frequency * std::f32::consts::TAU).cos().abs(); // TAU = 2π
+            for mut settings in query.iter_mut() {
+                let max_red = 255.0 / 255.0; 
+                let min_other = 76.5 / 255.0; 
+
+                settings.color = Vec3::new(
+                    max_red,
+                    min_other * (1.0 - time_cos),
+                    min_other * (1.0 - time_cos),
+                );
+                settings.base_brightness = 0.15 + time_cos * 0.15; // Sharper brightness spike
+            }
+        }
+        else {
+            for mut settings in query.iter_mut() {
+                settings.base_brightness = 0.15;
+                settings.color = Vec3::new(0.0,0.0,0.0); 
+            }
+        }
+    } else {
+        return;
+    }
+    
 }


### PR DESCRIPTION
Change Vignette color on Low HP #146

When player's health is reduced to 25 percent or below, the vignette begins to oscillate with a mild red and fuller red. if hp increases back to above 25 percent, the normal vignette is restored. 