### PR TITLE
Fix Bow Auto-Aim Feature

### DIFF
--- a/game/src/game/player/player_behaviour.rs
+++ b/game/src/game/player/player_behaviour.rs
@@ -3,7 +3,6 @@ use bevy::transform::TransformSystem::TransformPropagate;
 use glam::{Vec2, Vec2Swizzles, Vec3Swizzles};
 use leafwing_input_manager::action_state::ActionState;
 use rapier2d::geometry::{Group, InteractionGroups};
-use rapier2d::na::ComplexField;
 use rapier2d::parry::query::TOIStatus;
 use theseeker_engine::assets::animation::SpriteAnimation;
 use theseeker_engine::gent::Gent;
@@ -83,6 +82,7 @@ impl Plugin for PlayerBehaviorPlugin {
                         .before(player_jump)
                         .run_if(any_with_component::<Falling>),
                     bow_auto_aim
+                        .after(player_move)
                         .before(player_attack)
                         .run_if(is_player_using_bow),
                 )


### PR DESCRIPTION
- Added system ordering to `bow_auto_aim` so it runs after `player_move` (which handles the player facing) to attempt to fix the regression in the bow auto aim feature.