### PR TITLE
Hammer Weapon Set

### DIFF
--- a/assets/animations.assets.ron
+++ b/assets/animations.assets.ron
@@ -145,6 +145,18 @@
         rows: 1,
         columns: 12,
     ),
+    "anim.player.HammerBasicRun": File (
+        path: "animations/player/hammer/BasicIdle.anim.toml",
+    ),
+    "anim.player.HammerBasicRun.image": File (
+        path: "animations/player/hammer/BasicIdleSheet.png",
+    ),
+    "anim.player.HammerBasicRun.atlas": TextureAtlasLayout (
+        tile_size_x: 48.,
+        tile_size_y: 48.,
+        rows: 1,
+        columns: 29,
+    ),
     "anim.player.SwordBasicAir": File (
         path: "animations/player/sword/BasicAir.anim.toml",
     ),

--- a/assets/animations/player/hammer/BasicAir.anim.toml
+++ b/assets/animations/player/hammer/BasicAir.anim.toml
@@ -6,6 +6,6 @@ frame_min = 1
 frame_max = 18
 frame_start = 7
 
-# I set the start frame to 7 which is the regular foward attack while in air.
+# I set the start frame to 7 which is the regular forward attack while in air.
 # The last frame index of the regular forward attack is 12
 # Then for the 'pogo' (downward) air attack, the start frame index is 13 and end is 18

--- a/assets/animations/player/hammer/BasicIdle.anim.toml
+++ b/assets/animations/player/hammer/BasicIdle.anim.toml
@@ -6,13 +6,139 @@ frame_min = 1
 frame_max = 29
 frame_start = 1
 
+# From air
+[[script]]
+run_on_playback_control = "Start"
+if_previous_script_key = "anim.player.HammerBasicAir"
+if_oldanim_frame_was = 1
+action = "SetFrameNow"
+frame_index = 2
+
+[[script]]
+run_on_playback_control = "Start"
+if_previous_script_key = "anim.player.HammerBasicAir"
+if_oldanim_frame_was = 2
+action = "SetFrameNow"
+frame_index = 3
+
+[[script]]
+run_on_playback_control = "Start"
+if_previous_script_key = "anim.player.HammerBasicAir"
+if_oldanim_frame_was = 3
+action = "SetFrameNow"
+frame_index = 4
+
+[[script]]
+run_on_playback_control = "Start"
+if_previous_script_key = "anim.player.HammerBasicAir"
+if_oldanim_frame_was = 4
+action = "SetFrameNow"
+frame_index = 5
+
+[[script]]
+run_on_playback_control = "Start"
+if_previous_script_key = "anim.player.HammerBasicAir"
+if_oldanim_frame_was = 5
+action = "SetFrameNext"
+frame_index = 6
+
+[[script]]
+run_on_playback_control = "Start"
+if_previous_script_key = "anim.player.HammerBasicAir"
+if_oldanim_frame_was = 6
+action = "SetFrameNow"
+frame_index = 7
+
+[[script]]
+run_on_playback_control = "Start"
+if_previous_script_key = "anim.player.HammerBasicAir"
+if_oldanim_frame_was = 7
+action = "SetFrameNow"
+frame_index = 9
+
+[[script]]
+run_on_playback_control = "Start"
+if_previous_script_key = "anim.player.HammerBasicAir"
+if_oldanim_frame_was = 8
+action = "SetFrameNow"
+frame_index = 10
+
+[[script]]
+run_on_playback_control = "Start"
+if_previous_script_key = "anim.player.HammerBasicAir"
+if_oldanim_frame_was = 9
+action = "SetFrameNow"
+frame_index = 11
+
+[[script]]
+run_on_playback_control = "Start"
+if_previous_script_key = "anim.player.HammerBasicAir"
+if_oldanim_frame_was = 10
+action = "SetFrameNext"
+frame_index = 12
+
+[[script]]
+run_on_playback_control = "Start"
+if_previous_script_key = "anim.player.HammerBasicAir"
+if_oldanim_frame_was = 11
+action = "SetFrameNow"
+frame_index = 13
+
+[[script]]
+run_on_playback_control = "Start"
+if_previous_script_key = "anim.player.HammerBasicAir"
+if_oldanim_frame_was = 12
+action = "SetFrameNow"
+frame_index = 14
+
+[[script]]
+run_on_playback_control = "Start"
+if_previous_script_key = "anim.player.HammerBasicAir"
+if_oldanim_frame_was = 13
+action = "SetFrameNow"
+frame_index = 16
+
+[[script]]
+run_on_playback_control = "Start"
+if_previous_script_key = "anim.player.HammerBasicAir"
+if_oldanim_frame_was = 14
+action = "SetFrameNow"
+frame_index = 17
+
+[[script]]
+run_on_playback_control = "Start"
+if_previous_script_key = "anim.player.HammerBasicAir"
+if_oldanim_frame_was = 15
+action = "SetFrameNext"
+frame_index = 18
+
+[[script]]
+run_on_playback_control = "Start"
+if_previous_script_key = "anim.player.HammerBasicAir"
+if_oldanim_frame_was = 16
+action = "SetFrameNext"
+frame_index = 19
+
+[[script]]
+run_on_playback_control = "Start"
+if_previous_script_key = "anim.player.HammerBasicAir"
+if_oldanim_frame_was = 17
+action = "SetFrameNext"
+frame_index = 20
+
+[[script]]
+run_on_playback_control = "Start"
+if_previous_script_key = "anim.player.HammerBasicAir"
+if_oldanim_frame_was = 18
+action = "SetFrameNext"
+frame_index = 21
 
 # VARIANT 1 INIT
 [[script]]
 run_on_playback_control = "Start"
 forbid_slots_all = ["AttackTransition"]
 action = "SetFrameNow"
-frame_index = 1
+frame_index = 2
 
 # VARIANT 2 INIT
 [[script]]
@@ -20,7 +146,7 @@ run_on_playback_control = "Start"
 forbid_slots_all = ["AttackTransition"]
 if_runcount_quant = "2"
 action = "SetFrameNow"
-frame_index = 8
+frame_index = 9
 
 # VARIANT 3 INIT
 [[script]]
@@ -28,7 +154,7 @@ run_on_playback_control = "Start"
 forbid_slots_all = ["AttackTransition"]
 if_runcount_quant = "3"
 action = "SetFrameNow"
-frame_index = 15
+frame_index = 16
 
 
 # Support left/right flipping

--- a/assets/player.cfg.toml
+++ b/assets/player.cfg.toml
@@ -129,8 +129,18 @@ hammer_attack_damage = 20.0
 # Base bow attack damage
 bow_attack_damage = 10.0
 
-# Number of kills to trigger passive gain
-passive_gain_rate = 3.0
-
 # Velocity of the projectiles fired by the Bow weapon
 arrow_velocity = 1000.0
+
+# Default configuration values for on hit camera screen shake
+default_on_hit_screenshake_strength = 0.9
+default_on_hit_screenshake_duration_secs = 0.1
+default_on_hit_screenshake_frequency = 2.0
+
+# Hammer-specific configuration values for on hit camera screen shake
+hammer_on_hit_screenshake_strength = 1.35
+hammer_on_hit_screenshake_duration_secs = 0.2
+hammer_on_hit_screenshake_frequency = 2.5
+
+# Number of kills to trigger passive gain
+passive_gain_rate = 3.0

--- a/assets/player.cfg.toml
+++ b/assets/player.cfg.toml
@@ -4,6 +4,10 @@
 # (in pixels/second)
 max_move_vel = 70.0
 
+# The maximum horizontal velocity the player can move at while using the Hammer weapon.
+# (in pixels/second)
+hammer_max_move_vel = 35.0
+
 # The maximum downward velocity the player can fall at.
 # (in pixels/second)
 max_fall_vel = 180.0

--- a/assets/player.cfg.toml
+++ b/assets/player.cfg.toml
@@ -84,26 +84,29 @@ wall_pushback = 50.0
 # Ticks for wall pushback velocity; determines how long movement is locked for
 wall_pushback_ticks = 5.0
 
-# Pushback velocity on basic melee hits
-melee_self_pushback = 60.0
+# Pushback velocity on basic sword hits
+sword_self_pushback = 60.0
 
-# Ticks for melee pushback velocity; determines how long movement is locked for
-melee_self_pushback_ticks = 3.0
+# Ticks for sword pushback velocity; determines how long movement is locked for
+sword_self_pushback_ticks = 3.0
 
-# Knockback velocity applied to enemy on basic melee hit
-melee_pushback = 60.0
+# Knockback velocity applied to enemy on basic sword hit
+sword_pushback = 60.0
 
-# Ticks for melee knockback velocity; determines how long movement is locked for
-melee_pushback_ticks = 12.0
+# Ticks for sword knockback velocity; determines how long movement is locked for
+sword_pushback_ticks = 12.0
 
-# Base sword attack damage
-sword_attack_damage = 20.0
+# Pushback velocity on basic hammer hits
+hammer_self_pushback = 60.0
 
-# Base hammer attack damage
-hammer_attack_damage = 20.0
+# Ticks for hammer pushback velocity; determines how long movement is locked for
+hammer_self_pushback_ticks = 3.0
 
-# Base bow attack damage
-bow_attack_damage = 10.0
+# Knockback velocity applied to enemy on basic hammer hit
+hammer_pushback = 60.0
+
+# Ticks for hammer knockback velocity; determines how long movement is locked for
+hammer_pushback_ticks = 12.0
 
 # Pushback velocity on basic bow shots
 bow_self_pushback = 0.0
@@ -116,6 +119,15 @@ bow_pushback = 60.0
 
 # Ticks for melee knockback velocity; determines how long movement is locked for
 bow_pushback_ticks = 5.0
+
+# Base sword attack damage
+sword_attack_damage = 20.0
+
+# Base hammer attack damage
+hammer_attack_damage = 20.0
+
+# Base bow attack damage
+bow_attack_damage = 10.0
 
 # Number of kills to trigger passive gain
 passive_gain_rate = 3.0

--- a/assets/player.cfg.toml
+++ b/assets/player.cfg.toml
@@ -96,11 +96,14 @@ melee_pushback = 60.0
 # Ticks for melee knockback velocity; determines how long movement is locked for
 melee_pushback_ticks = 12.0
 
-# Base bow attack damage
-bow_attack_damage = 10.0
+# Base sword attack damage
+sword_attack_damage = 20.0
+
+# Base hammer attack damage
+hammer_attack_damage = 20.0
 
 # Base bow attack damage
-sword_attack_damage = 20.0
+bow_attack_damage = 10.0
 
 # Pushback velocity on basic bow shots
 bow_self_pushback = 0.0

--- a/game/src/game/attack/mod.rs
+++ b/game/src/game/attack/mod.rs
@@ -13,10 +13,11 @@ use theseeker_engine::physics::{
 use super::enemy::{Defense, EnemyGfx, EnemyStateSet};
 use super::gentstate::{Dead, Facing};
 use super::physics::Knockback;
+use super::player::player_weapon::CurrentWeapon;
 use super::player::{
     on_crit_cooldown_reduce, on_hit_exit_stealthing,
-    on_stealth_hit_cooldown_reset, Passive, Passives, Player, PlayerGfx,
-    PlayerStateSet, StatusModifier,
+    on_stealth_hit_cooldown_reset, Passive, Passives, Player, PlayerConfig,
+    PlayerGfx, PlayerStateSet, StatusModifier,
 };
 use crate::game::attack::arc_attack::{arc_projectile, Projectile};
 use crate::game::attack::particles::AttackParticlesPlugin;
@@ -473,11 +474,27 @@ pub fn kill_on_damage(
 fn on_hit_cam_shake(
     query: Query<&Attack, Added<Hit>>,
     p_query: Query<Entity, With<Player>>,
+    config: Res<PlayerConfig>,
+    weapon: CurrentWeapon,
     mut commands: Commands,
 ) {
     for attack in query.iter() {
         if let Ok(_entity) = p_query.get(attack.attacker) {
-            commands.insert_resource(CameraShake::new(0.9, 0.1, 2.0));
+            let camera_shake = if weapon.is_wielding_hammer() {
+                CameraShake::new(
+                    config.hammer_on_hit_screenshake_strength,
+                    config.hammer_on_hit_screenshake_duration_secs,
+                    config.hammer_on_hit_screenshake_frequency,
+                )
+            } else {
+                CameraShake::new(
+                    config.default_on_hit_screenshake_strength,
+                    config.default_on_hit_screenshake_duration_secs,
+                    config.default_on_hit_screenshake_frequency,
+                )
+            };
+
+            commands.insert_resource(camera_shake);
         }
     }
 }

--- a/game/src/game/player/mod.rs
+++ b/game/src/game/player/mod.rs
@@ -888,6 +888,9 @@ pub struct PlayerConfig {
     /// Base sword attack damage
     sword_attack_damage: f32,
 
+    /// Base hammer attack damage
+    hammer_attack_damage: f32,
+
     /// Base bow attack damage
     bow_attack_damage: f32,
 
@@ -982,6 +985,7 @@ fn update_player_config(config: &mut PlayerConfig, cfg: &DynamicConfig) {
     update_field(&mut errors, &cfg.0, "melee_pushback", |val| config.melee_pushback = val);
     update_field(&mut errors, &cfg.0, "melee_pushback_ticks", |val| config.melee_pushback_ticks = val as u32);
     update_field(&mut errors, &cfg.0, "sword_attack_damage", |val| config.sword_attack_damage = val);
+    update_field(&mut errors, &cfg.0, "hammer_attack_damage", |val| config.hammer_attack_damage = val);
     update_field(&mut errors, &cfg.0, "bow_attack_damage", |val| config.bow_attack_damage = val);
     update_field(&mut errors, &cfg.0, "bow_self_pushback", |val| config.bow_self_pushback = val);
     update_field(&mut errors, &cfg.0, "bow_self_pushback_ticks", |val| config.bow_self_pushback_ticks = val as u32);

--- a/game/src/game/player/mod.rs
+++ b/game/src/game/player/mod.rs
@@ -783,6 +783,11 @@ pub struct PlayerConfig {
     /// (in pixels/second)
     max_move_vel: f32,
 
+    /// The maximum horizontal velocity the player can move at while using the Hammer weapon.
+    ///
+    /// (in pixels/second)
+    hammer_max_move_vel: f32,
+
     /// The maximum downward velocity the player can fall at.
     ///
     /// (in pixels/second)
@@ -978,6 +983,7 @@ fn load_player_config(
 fn update_player_config(config: &mut PlayerConfig, cfg: &DynamicConfig) {
     let mut errors = Vec::new();
     update_field(&mut errors, &cfg.0, "max_move_vel", |val| config.max_move_vel = val);
+    update_field(&mut errors, &cfg.0, "hammer_max_move_vel", |val| config.hammer_max_move_vel = val);
     update_field(&mut errors, &cfg.0, "max_fall_vel", |val| config.max_fall_vel = val);
     update_field(&mut errors, &cfg.0, "move_accel_init", |val| config.move_accel_init = val);
     update_field(&mut errors, &cfg.0, "move_accel", |val| config.move_accel = val);

--- a/game/src/game/player/mod.rs
+++ b/game/src/game/player/mod.rs
@@ -132,7 +132,8 @@ pub enum PlayerAction {
     Whirl,
     Stealth,
     Fall,
-    SwapWeapon,
+    SwapCombatStyle,
+    SwapMeleeWeapon,
     Interact,
     ToggleControlOverlay,
 }
@@ -399,10 +400,17 @@ fn setup_player(
                         KeyCode::Semicolon,
                     )
                     .with(PlayerAction::Stealth, KeyCode::Digit4)
-                    .with(PlayerAction::SwapWeapon, KeyCode::KeyH)
                     .with(
-                        PlayerAction::SwapWeapon,
+                        PlayerAction::SwapCombatStyle,
+                        KeyCode::KeyH,
+                    )
+                    .with(
+                        PlayerAction::SwapCombatStyle,
                         KeyCode::Backquote,
+                    )
+                    .with(
+                        PlayerAction::SwapMeleeWeapon,
+                        KeyCode::KeyG,
                     )
                     .with(PlayerAction::Interact, KeyCode::KeyF)
                     .with(

--- a/game/src/game/player/mod.rs
+++ b/game/src/game/player/mod.rs
@@ -581,15 +581,11 @@ impl Whirling {
 
 /// Differentiates between different types of dashing
 //#[allow(clippy::enum_variant_names)]
-#[derive(Clone, Copy, Eq, PartialEq, Hash, Debug)]
+#[derive(Clone, Copy, Eq, PartialEq, Hash, Debug, Default)]
 pub enum DashType {
+    #[default]
     Horizontal,
     Downward,
-}
-impl Default for DashType {
-    fn default() -> Self {
-        return DashType::Horizontal;
-    }
 }
 
 #[derive(Component, Debug, Default)]
@@ -604,32 +600,32 @@ impl Dashing {
     pub fn from_action_state(action_state: &ActionState<PlayerAction>) -> Self {
         if action_state.pressed(&PlayerAction::Fall) {
             println!("dashing down!");
-            return Self {
+            Self {
                 dash_type: DashType::Downward,
                 ..default()
-            };
+            }
         } else {
             println!("dashing horizontally!");
-            return Self {
+            Self {
                 dash_type: DashType::Horizontal,
                 ..default()
-            };
+            }
         }
     }
 
     pub fn dash_duration(&self, config: &PlayerConfig) -> f32 {
-        return match self.dash_type {
+        match self.dash_type {
             DashType::Horizontal => config.dash_duration,
             DashType::Downward => config.dash_down_duration,
-        };
+        }
     }
 
     pub fn is_down_dash(&self) -> bool {
-        return self.dash_type == DashType::Downward;
+        self.dash_type == DashType::Downward
     }
 
     pub fn is_horizontal_dash(&self) -> bool {
-        return self.dash_type == DashType::Horizontal;
+        self.dash_type == DashType::Horizontal
     }
 
     pub fn set_player_velocity(
@@ -1333,7 +1329,6 @@ pub fn dash_icon_fx(
     mut commands: Commands,
     mut query: Query<(Entity, &DashIcon, &mut Sprite)>,
     time: Res<GameTime>,
-    config: Res<PlayerConfig>,
 ) {
     for (entity, icon, mut sprite) in query.iter_mut() {
         let d = time.time_in_seconds() as f32 - icon.time;

--- a/game/src/game/player/mod.rs
+++ b/game/src/game/player/mod.rs
@@ -1,6 +1,6 @@
 mod player_anim;
 mod player_behaviour;
-mod player_weapon;
+pub mod player_weapon;
 use bevy::utils::hashbrown::HashMap;
 use leafwing_input_manager::action_state::ActionState;
 use leafwing_input_manager::axislike::VirtualAxis;
@@ -917,6 +917,20 @@ pub struct PlayerConfig {
     /// Velocity of the projectiles fired by the Bow weapon
     arrow_velocity: f32,
 
+    /// Default strength for on hit camera screen shake
+    pub default_on_hit_screenshake_strength: f32,
+    /// Default duration (in seconds) for on hit camera screen shake
+    pub default_on_hit_screenshake_duration_secs: f32,
+    /// Default frequency for on hit camera screen shake
+    pub default_on_hit_screenshake_frequency: f32,
+
+    /// Hammer-specific strength for on hit camera screen shake
+    pub hammer_on_hit_screenshake_strength: f32,
+    /// Hammer-specific duration (in seconds) for on hit camera screen shake
+    pub hammer_on_hit_screenshake_duration_secs: f32,
+    /// Hammer-specific frequency for on hit camera screen shake
+    pub hammer_on_hit_screenshake_frequency: f32,
+
     /// How many kills to trigger a passive gain
     passive_gain_rate: u32,
 }
@@ -1003,8 +1017,14 @@ fn update_player_config(config: &mut PlayerConfig, cfg: &DynamicConfig) {
     update_field(&mut errors, &cfg.0, "bow_self_pushback_ticks", |val| config.bow_self_pushback_ticks = val as u32);
     update_field(&mut errors, &cfg.0, "bow_pushback", |val| config.bow_pushback = val);
     update_field(&mut errors, &cfg.0, "bow_pushback_ticks", |val| config.bow_pushback_ticks = val as u32);
-    update_field(&mut errors, &cfg.0, "passive_gain_rate", |val| config.passive_gain_rate = val as u32);
     update_field(&mut errors, &cfg.0, "arrow_velocity", |val| config.arrow_velocity = val);
+    update_field(&mut errors, &cfg.0, "default_on_hit_screenshake_strength", |val| config.default_on_hit_screenshake_strength = val);
+    update_field(&mut errors, &cfg.0, "default_on_hit_screenshake_duration_secs", |val| config.default_on_hit_screenshake_duration_secs = val);
+    update_field(&mut errors, &cfg.0, "default_on_hit_screenshake_frequency", |val| config.default_on_hit_screenshake_frequency = val);
+    update_field(&mut errors, &cfg.0, "hammer_on_hit_screenshake_strength", |val| config.hammer_on_hit_screenshake_strength = val);
+    update_field(&mut errors, &cfg.0, "hammer_on_hit_screenshake_duration_secs", |val| config.hammer_on_hit_screenshake_duration_secs = val);
+    update_field(&mut errors, &cfg.0, "hammer_on_hit_screenshake_frequency", |val| config.hammer_on_hit_screenshake_frequency = val);
+    update_field(&mut errors, &cfg.0, "passive_gain_rate", |val| config.passive_gain_rate = val as u32);
 
     for error in errors{
        warn!("failed to load player cfg value: {}", error);

--- a/game/src/game/player/mod.rs
+++ b/game/src/game/player/mod.rs
@@ -1175,7 +1175,7 @@ fn player_update_passive_buffs(
         let mut speed = 1.;
         let mut cdr = 1.;
         if passives.contains(&Passive::GlowingShard) {
-            attack *= (1. + 0.1 * enemies_nearby.0 as f32);
+            attack *= 1. + 0.1 * enemies_nearby.0 as f32;
         }
         if passives.contains(&Passive::SerpentRing) {
             speed *= 1.2;
@@ -1459,7 +1459,7 @@ pub fn on_xp_heal(
 ) {
     if let Ok((passives, mut health)) = query.get_single_mut() {
         if passives.contains(&Passive::Bloodstone) {
-            for event in xp_event.read() {
+            for _event in xp_event.read() {
                 health.current = (health.current + 2).min(health.max);
             }
         }

--- a/game/src/game/player/mod.rs
+++ b/game/src/game/player/mod.rs
@@ -869,26 +869,29 @@ pub struct PlayerConfig {
     /// Ticks for wall pushback velocity; determines how long movement is locked for
     wall_pushback_ticks: u32,
 
-    /// Self pushback velocity on basic melee hits
-    melee_self_pushback: f32,
+    /// Self pushback velocity on basic sword hits
+    sword_self_pushback: f32,
 
-    /// Ticks for melee self pushback velocity; determines how long movement is locked for
-    melee_self_pushback_ticks: u32,
+    /// Ticks for sword self pushback velocity; determines how long movement is locked for
+    sword_self_pushback_ticks: u32,
 
-    /// Knockback velocity applied to enemy on basic melee hit
-    melee_pushback: f32,
+    /// Knockback velocity applied to enemy on basic sword hit
+    sword_pushback: f32,
 
-    /// Ticks for melee knockback velocity; determines how long movement is locked for
-    melee_pushback_ticks: u32,
+    /// Ticks for sword knockback velocity; determines how long movement is locked for
+    sword_pushback_ticks: u32,
 
-    /// Base sword attack damage
-    sword_attack_damage: f32,
+    /// Self pushback velocity on basic hammer hits
+    hammer_self_pushback: f32,
 
-    /// Base hammer attack damage
-    hammer_attack_damage: f32,
+    /// Ticks for hammer self pushback velocity; determines how long movement is locked for
+    hammer_self_pushback_ticks: u32,
 
-    /// Base bow attack damage
-    bow_attack_damage: f32,
+    /// Knockback velocity applied to enemy on basic hammer hit
+    hammer_pushback: f32,
+
+    /// Ticks for hammer knockback velocity; determines how long movement is locked for
+    hammer_pushback_ticks: u32,
 
     /// Pushback velocity on basic bow shots
     bow_self_pushback: f32,
@@ -901,6 +904,15 @@ pub struct PlayerConfig {
 
     /// Ticks for melee knockback velocity; determines how long movement is locked for
     bow_pushback_ticks: u32,
+
+    /// Base sword attack damage
+    sword_attack_damage: f32,
+
+    /// Base hammer attack damage
+    hammer_attack_damage: f32,
+
+    /// Base bow attack damage
+    bow_attack_damage: f32,
 
     /// Velocity of the projectiles fired by the Bow weapon
     arrow_velocity: f32,
@@ -976,10 +988,14 @@ fn update_player_config(config: &mut PlayerConfig, cfg: &DynamicConfig) {
     update_field(&mut errors, &cfg.0, "max_health", |val| config.max_health = val as u32);
     update_field(&mut errors, &cfg.0, "wall_pushback", |val| config.wall_pushback = val);
     update_field(&mut errors, &cfg.0, "wall_pushback_ticks", |val| config.wall_pushback_ticks = val as u32);
-    update_field(&mut errors, &cfg.0, "melee_self_pushback", |val| config.melee_self_pushback = val);
-    update_field(&mut errors, &cfg.0, "melee_self_pushback_ticks", |val| config.melee_self_pushback_ticks = val as u32);
-    update_field(&mut errors, &cfg.0, "melee_pushback", |val| config.melee_pushback = val);
-    update_field(&mut errors, &cfg.0, "melee_pushback_ticks", |val| config.melee_pushback_ticks = val as u32);
+    update_field(&mut errors, &cfg.0, "sword_self_pushback", |val| config.sword_self_pushback = val);
+    update_field(&mut errors, &cfg.0, "sword_self_pushback_ticks", |val| config.sword_self_pushback_ticks = val as u32);
+    update_field(&mut errors, &cfg.0, "sword_pushback", |val| config.sword_pushback = val);
+    update_field(&mut errors, &cfg.0, "sword_pushback_ticks", |val| config.sword_pushback_ticks = val as u32);
+    update_field(&mut errors, &cfg.0, "hammer_self_pushback", |val| config.hammer_self_pushback = val);
+    update_field(&mut errors, &cfg.0, "hammer_self_pushback_ticks", |val| config.hammer_self_pushback_ticks = val as u32);
+    update_field(&mut errors, &cfg.0, "hammer_pushback", |val| config.hammer_pushback = val);
+    update_field(&mut errors, &cfg.0, "hammer_pushback_ticks", |val| config.hammer_pushback_ticks = val as u32);
     update_field(&mut errors, &cfg.0, "sword_attack_damage", |val| config.sword_attack_damage = val);
     update_field(&mut errors, &cfg.0, "hammer_attack_damage", |val| config.hammer_attack_damage = val);
     update_field(&mut errors, &cfg.0, "bow_attack_damage", |val| config.bow_attack_damage = val);

--- a/game/src/game/player/mod.rs
+++ b/game/src/game/player/mod.rs
@@ -1077,6 +1077,18 @@ impl PlayerStats {
         self.effective_stats[&stat]
     }
 
+    pub fn set(&mut self, stat: StatType, value: f32) {
+        if let Some(effective_stat) = self.effective_stats.get_mut(&stat) {
+            *effective_stat = value;
+        }
+    }
+
+    pub fn reset_stat(&mut self, stat: StatType) {
+        if let Some(effective_stat) = self.effective_stats.get_mut(&stat) {
+            *effective_stat = self.base_stats[&stat];
+        }
+    }
+
     pub fn reset_stats(&mut self) {
         self.effective_stats = self.base_stats.clone();
     }

--- a/game/src/game/player/player_anim.rs
+++ b/game/src/game/player/player_anim.rs
@@ -205,10 +205,11 @@ fn player_attacking_animation(
 fn player_whirling_animation(
     query: Query<&Gent, Added<Whirling>>,
     mut gfx_query: Query<&mut ScriptPlayer<SpriteAnimation>, With<PlayerGfx>>,
+    weapon: CurrentWeapon,
 ) {
     for gent in query.iter() {
         if let Ok(mut player) = gfx_query.get_mut(gent.e_gfx) {
-            player.play_key("anim.player.SwordWhirling")
+            player.play_key(&weapon.whirling_anim_key());
         }
     }
 }

--- a/game/src/game/player/player_anim.rs
+++ b/game/src/game/player/player_anim.rs
@@ -1,4 +1,4 @@
-use bevy::prelude::{DetectChanges, Ref, RemovedComponents};
+use bevy::prelude::{DetectChanges, Ref};
 use theseeker_engine::assets::animation::SpriteAnimation;
 use theseeker_engine::gent::Gent;
 use theseeker_engine::physics::LinearVelocity;
@@ -17,7 +17,7 @@ use crate::prelude::{
     Res, With, Without,
 };
 
-use super::player_weapon::PlayerWeapon;
+use super::player_weapon::CurrentWeapon;
 
 /// play animations here, run after transitions
 pub struct PlayerAnimationPlugin;
@@ -160,7 +160,7 @@ fn player_attacking_animation(
     >,
     mut gfx_query: Query<&mut ScriptPlayer<SpriteAnimation>, With<PlayerGfx>>,
     config: Res<PlayerConfig>,
-    weapon: Res<PlayerWeapon>,
+    weapon: CurrentWeapon,
 ) {
     for (gent, is_falling, is_jumping, is_running, hitfrozen, attacking) in
         query.iter()
@@ -169,7 +169,6 @@ fn player_attacking_animation(
             let hitfrozen = hitfrozen
                 .map(|f| f.0 < config.hitfreeze_ticks)
                 .unwrap_or(false);
-            // let current = player.current_key().unwrap_or("").clone();
             player.set_slot("AttackTransition", false);
             let basic_air_anim_key_str = &weapon.get_anim_key("BasicAir");
             let basic_run_anim_key_str = &weapon.get_anim_key("BasicRun");
@@ -246,7 +245,7 @@ fn sprite_flip(
     mut current_direction: Local<bool>,
     mut old_direction: Local<bool>,
     time: Res<GameTime>,
-    weapon: Res<PlayerWeapon>,
+    weapon: CurrentWeapon,
 ) {
     for (facing, gent, wall_slide_time) in query.iter() {
         if let Ok(mut player) = gfx_query.get_mut(gent.e_gfx) {

--- a/game/src/game/player/player_anim.rs
+++ b/game/src/game/player/player_anim.rs
@@ -89,20 +89,15 @@ fn player_falling_animation(
                     {
                         player.play_key("anim.player.WallSlide");
                     }
-                } else {
-                    if velocity.y < 0.
-                        && player.current_key().unwrap_or("")
-                            != "anim.player.Fall"
-                    {
-                        player.play_key("anim.player.Fall");
-                    }
-                }
-            } else {
-                if velocity.y < 0.
+                } else if velocity.y < 0.
                     && player.current_key().unwrap_or("") != "anim.player.Fall"
                 {
                     player.play_key("anim.player.Fall");
                 }
+            } else if velocity.y < 0.
+                && player.current_key().unwrap_or("") != "anim.player.Fall"
+            {
+                player.play_key("anim.player.Fall");
             }
         }
     }
@@ -190,12 +185,10 @@ fn player_attacking_animation(
                         player.set_slot("AttackTransition", true);
                     }
                 }
-            } else {
-                if player.current_key() != Some(basic_idle_anim_key_str) {
-                    player.play_key(basic_idle_anim_key_str);
-                    if !attacking.is_added() {
-                        player.set_slot("AttackTransition", true);
-                    }
+            } else if player.current_key() != Some(basic_idle_anim_key_str) {
+                player.play_key(basic_idle_anim_key_str);
+                if !attacking.is_added() {
+                    player.set_slot("AttackTransition", true);
                 }
             }
         }

--- a/game/src/game/player/player_behaviour.rs
+++ b/game/src/game/player/player_behaviour.rs
@@ -1300,7 +1300,7 @@ fn player_attack(
                     if let PlayerMeleeWeapon::Hammer = *melee_weapon {
                         player_stats.set(
                             StatType::MoveVelMax,
-                            config.max_move_vel / 2.0,
+                            config.hammer_max_move_vel,
                         );
                     }
 
@@ -1441,7 +1441,7 @@ pub fn player_whirl(
             if let PlayerMeleeWeapon::Hammer = *melee_weapon {
                 player_stats.set(
                     StatType::MoveVelMax,
-                    config.max_move_vel / 2.0,
+                    config.hammer_max_move_vel,
                 );
             }
 

--- a/game/src/game/player/player_behaviour.rs
+++ b/game/src/game/player/player_behaviour.rs
@@ -15,7 +15,7 @@ use theseeker_engine::physics::{
 use theseeker_engine::script::ScriptPlayer;
 
 use super::arc_attack::{Arrow, Projectile};
-use super::player_weapon::PlayerCombatStyle;
+use super::player_weapon::{PlayerCombatStyle, PlayerMeleeWeapon};
 use super::{
     dash_icon_fx, player_dash_fx, AttackBundle, CanStealth, DashIcon,
     DashStrike, DashType, JumpCount, Knockback, PlayerStats, Pushback,
@@ -1183,6 +1183,7 @@ fn player_attack(
     mut commands: Commands,
     config: Res<PlayerConfig>,
     combat_style: Res<PlayerCombatStyle>,
+    melee_weapon: Res<PlayerMeleeWeapon>,
     time: Res<GameTime>,
 ) {
     for (
@@ -1262,6 +1263,13 @@ fn player_attack(
                         .id()
                 },
                 PlayerCombatStyle::Melee => {
+                    let damage = match *melee_weapon {
+                        PlayerMeleeWeapon::Hammer => {
+                            config.hammer_attack_damage
+                        },
+                        PlayerMeleeWeapon::Sword => config.sword_attack_damage,
+                    };
+
                     commands
                         .spawn((
                             TransformBundle::from_transform(
@@ -1273,11 +1281,7 @@ fn player_attack(
                                 PLAYER_ATTACK,
                                 ENEMY_HURT,
                             )),
-                            Attack::new(
-                                16,
-                                entity,
-                                config.sword_attack_damage * stat_mod.attack,
-                            ),
+                            Attack::new(16, entity, damage * stat_mod.attack),
                             SelfPushback(Knockback::new(
                                 Vec2::new(
                                     config.melee_self_pushback

--- a/game/src/game/player/player_behaviour.rs
+++ b/game/src/game/player/player_behaviour.rs
@@ -65,9 +65,10 @@ impl Plugin for PlayerBehaviorPlugin {
                     player_run.run_if(any_with_component::<Running>),
                     player_jump.run_if(any_with_component::<Jumping>),
                     player_dash_strike.run_if(any_with_component::<DashStrike>),
-                    player_dash.run_if(any_with_component::<Dashing>),
-                    player_dash_fx
-                        .after(player_dash)
+                    (
+                        player_dash,
+                        player_dash_fx.after(player_dash),
+                    )
                         .run_if(any_with_component::<Dashing>),
                     dash_icon_fx
                         .after(player_dash_fx)

--- a/game/src/game/player/player_weapon.rs
+++ b/game/src/game/player/player_weapon.rs
@@ -1,13 +1,13 @@
 use bevy::app::Update;
 use bevy::ecs::system::SystemParam;
-use bevy::prelude::Res;
+use bevy::prelude::{in_state, IntoSystemConfigs, Res};
 use leafwing_input_manager::prelude::ActionState;
 use strum_macros::Display;
 
 use crate::game::player::{Player, PlayerAction};
 use crate::prelude::{App, Plugin, Query, ResMut, Resource, With};
 
-use super::PlayerConfig;
+use super::{GameState, PlayerConfig};
 
 pub(crate) struct PlayerWeaponPlugin;
 
@@ -18,7 +18,8 @@ impl Plugin for PlayerWeaponPlugin {
         app.insert_resource(PlayerCombatStyle::default());
         app.add_systems(
             Update,
-            (swap_combat_style, swap_melee_weapon),
+            (swap_combat_style, swap_melee_weapon)
+                .run_if(in_state(GameState::Playing)),
         );
     }
 }

--- a/game/src/game/player/player_weapon.rs
+++ b/game/src/game/player/player_weapon.rs
@@ -7,6 +7,8 @@ use strum_macros::Display;
 use crate::game::player::{Player, PlayerAction};
 use crate::prelude::{App, Plugin, Query, ResMut, Resource, With};
 
+use super::PlayerConfig;
+
 pub(crate) struct PlayerWeaponPlugin;
 
 impl Plugin for PlayerWeaponPlugin {
@@ -26,6 +28,13 @@ impl Plugin for PlayerWeaponPlugin {
     }
 }
 
+pub struct PushbackValues {
+    pub pushback: f32,
+    pub pushback_ticks: u32,
+    pub self_pushback: f32,
+    pub self_pushback_ticks: u32,
+}
+
 #[derive(Resource, Default, PartialEq, Eq, Display)]
 pub enum PlayerCombatStyle {
     Ranged,
@@ -38,6 +47,33 @@ pub enum PlayerMeleeWeapon {
     Hammer,
     #[default]
     Sword,
+}
+
+impl PlayerMeleeWeapon {
+    pub fn pushback_values(&self, config: &PlayerConfig) -> PushbackValues {
+        let (pushback, pushback_ticks, self_pushback, self_pushback_ticks) =
+            match self {
+                Self::Hammer => (
+                    config.hammer_pushback,
+                    config.hammer_pushback_ticks,
+                    config.hammer_self_pushback,
+                    config.hammer_self_pushback_ticks,
+                ),
+                Self::Sword => (
+                    config.sword_pushback,
+                    config.sword_pushback_ticks,
+                    config.sword_self_pushback,
+                    config.sword_self_pushback_ticks,
+                ),
+            };
+
+        PushbackValues {
+            pushback,
+            pushback_ticks,
+            self_pushback,
+            self_pushback_ticks,
+        }
+    }
 }
 
 #[derive(Resource, Default, PartialEq, Eq, Display)]

--- a/game/src/game/player/player_weapon.rs
+++ b/game/src/game/player/player_weapon.rs
@@ -100,6 +100,11 @@ impl CurrentWeapon<'_> {
         let weapon_str = self.melee_weapon.to_string();
         format!("anim.player.{weapon_str}Whirling")
     }
+
+    pub fn is_wielding_hammer(&self) -> bool {
+        *self.combat_style == PlayerCombatStyle::Melee
+            && *self.melee_weapon == PlayerMeleeWeapon::Hammer
+    }
 }
 
 impl std::fmt::Display for CurrentWeapon<'_> {

--- a/game/src/game/player/player_weapon.rs
+++ b/game/src/game/player/player_weapon.rs
@@ -1,6 +1,6 @@
 use bevy::app::Update;
 use bevy::ecs::system::SystemParam;
-use bevy::prelude::{resource_equals, IntoSystemConfigs, Res};
+use bevy::prelude::Res;
 use leafwing_input_manager::prelude::ActionState;
 use strum_macros::Display;
 
@@ -18,12 +18,7 @@ impl Plugin for PlayerWeaponPlugin {
         app.insert_resource(PlayerCombatStyle::default());
         app.add_systems(
             Update,
-            (
-                swap_combat_style,
-                swap_melee_weapon.run_if(resource_equals(
-                    PlayerCombatStyle::Melee,
-                )),
-            ),
+            (swap_combat_style, swap_melee_weapon),
         );
     }
 }

--- a/game/src/game/player/player_weapon.rs
+++ b/game/src/game/player/player_weapon.rs
@@ -58,6 +58,12 @@ impl CurrentWeapon<'_> {
         let weapon_str = self.to_string();
         format!("anim.player.{weapon_str}{action}")
     }
+
+    /// Retrieves the Whirling skill animation key for the currently equipped melee weapon.
+    pub fn whirling_anim_key(&self) -> String {
+        let weapon_str = self.melee_weapon.to_string();
+        format!("anim.player.{weapon_str}Whirling")
+    }
 }
 
 impl std::fmt::Display for CurrentWeapon<'_> {

--- a/game/src/ui/controls_overlay.rs
+++ b/game/src/ui/controls_overlay.rs
@@ -100,10 +100,14 @@ fn spawn_control_overlay(mut commands: Commands) {
                 row.control_icon("4");
             });
             container.row().with_children(|row| {
-                row.text("Swap Weapon: ");
+                row.text("Swap Melee/Ranged: ");
                 row.control_icon("H");
                 row.text(" or ");
                 row.control_icon("`");
+            });
+            container.row().with_children(|row| {
+                row.text("Swap Melee Weapon: ");
+                row.control_icon("G");
             });
             container.spacer();
             container.row().with_children(|row| {


### PR DESCRIPTION
Fixes #154 

- Reworked the `PlayerWeapon` plugin to include "combat styles" (melee/ranged) and differentiate the currently selected melee and ranged weapons.
- Implemented Hammer weapon with attacks and animations.
- Added a configurable movement slowdown to the Player while attacking with the Hammer.
- Added configurable base damage for both the Sword and Hammer weapons.
- Added configurable pushback settings for both the Sword and Hammer weapons.
- Added configurable screenshake settings for the Hammer weapon and a default one for the rest.
- Added and updated UI elements to the controls overlay to better explain the weapon swapping actions.
- Fixed several lints and typos.