### PR TITLE
Attempts to fix Attack hits not being registered

### DIFF
--- a/game/src/game/attack/mod.rs
+++ b/game/src/game/attack/mod.rs
@@ -4,6 +4,7 @@ pub mod particles;
 use std::mem;
 
 use arc_attack::Arrow;
+use bevy::transform::TransformSystem;
 use rapier2d::prelude::InteractionGroups;
 use theseeker_engine::gent::Gent;
 use theseeker_engine::physics::{
@@ -40,7 +41,8 @@ impl Plugin for AttackPlugin {
                 // (lifesteal, kill_on_damage, damage_flash).in_set(RespondToDamageInfoSet)
                 arc_projectile,
                 (
-                    determine_attack_targets,
+                    determine_attack_targets
+                        .before(TransformSystem::TransformPropagate),
                     apply_attack_modifications,
                     // DamageInfo event emitted here
                     apply_attack_damage,
@@ -194,12 +196,15 @@ pub struct Crit;
 
 // checks nearest entities, modifies attacks targets
 pub fn determine_attack_targets(
-    mut attack_query: Query<(
-        Entity,
-        &GlobalTransform,
-        &mut Attack,
-        &Collider,
-    )>,
+    mut attack_query: Query<
+        (
+            Entity,
+            &GlobalTransform,
+            &mut Attack,
+            &Collider,
+        ),
+        Changed<Collider>,
+    >,
     damageable_query: Query<
         &GlobalTransform,
         (With<Collider>, With<Health>, With<Gent>),
@@ -239,12 +244,11 @@ pub fn determine_attack_targets(
 
         // Get the closest targets
         let valid_targets = targets
-            .into_iter()
+            .iter()
             .take(attack.max_targets as usize - attack.damaged_set.len())
-            .map(|(e, _)| e)
-            .collect::<Vec<_>>();
+            .map(|(e, _)| e);
 
-        for entity in valid_targets.iter() {
+        for entity in valid_targets {
             // if we already damaged this entity
             if attack.damaged_set.contains(entity) {
                 continue;


### PR DESCRIPTION
Fixes #177 

- Ordered `determine_attack_targets` before transform propagation so attack intersections are calculated before entities were translated on this frame.