### PR TITLE
Update Controls Hint

### DIFF
--- a/game/src/ui/controls_overlay.rs
+++ b/game/src/ui/controls_overlay.rs
@@ -27,10 +27,14 @@ struct ControlsPopup {
 pub(super) fn plugin(app: &mut App) {
     app.add_systems(
         OnEnter(AppState::InGame),
-        (
-            spawn_control_overlay,
-            spawn_control_hint,
-        ),
+        spawn_control_overlay,
+    )
+    .add_systems(
+        OnTransition {
+            from: AppState::MainMenu,
+            to: AppState::InGame,
+        },
+        spawn_control_hint,
     )
     .add_systems(
         Update,

--- a/game/src/ui/controls_overlay.rs
+++ b/game/src/ui/controls_overlay.rs
@@ -271,7 +271,7 @@ impl<T: Spawn> ControlsOverlayUi for T {
                     margin: UiRect::new(
                         Val::Auto,
                         Val::Auto,
-                        Val::Percent(65.0),
+                        Val::Percent(40.0),
                         Val::Auto,
                     ),
                     padding: UiRect::axes(Val::Px(16.0), Val::Px(4.0)),


### PR DESCRIPTION
Fixes #179 

- Updated controls popup notification styles to show it on the screen properly.
- Display the controls popup notification only when starting a new game from the main menu.