### PR TITLE
Add Weapon Dependent Hit Sfx

### DIFF
--- a/assets/animations/spider/big/tier1/Sparks.anim.toml
+++ b/assets/animations/spider/big/tier1/Sparks.anim.toml
@@ -7,34 +7,34 @@ frame_max = 18
 frame_start = 1
 
 [[script]]
-run_on_slot_enable = "Hit"
+run_on_slot_enable = "AttackHit"
 action = "PlayAudio"
 volume = 1.0
 asset_key = "audio.game.SpiderGetDamage"
 
 [[script]]
-run_on_slot_enable = "Hit"
+run_on_slot_enable = "AttackHit"
 forbid_slots_all = ["SwordHit", "HammerHit", "BowHit"]
 action = "PlayAudio"
 volume = 0.15
 asset_key = "audio.game.ImpactBass"
 
 [[script]]
-run_on_slot_enable = "Hit"
+run_on_slot_enable = "AttackHit"
 require_slots_all = ["SwordHit"]
 action = "PlayAudio"
 volume = 0.15
 asset_key = "audio.game.SwordImpact"
 
 [[script]]
-run_on_slot_enable = "Hit"
+run_on_slot_enable = "AttackHit"
 require_slots_all = ["HammerHit"]
 action = "PlayAudio"
 volume = 0.15
 asset_key = "audio.game.HammerImpact"
 
 [[script]]
-run_on_slot_enable = "Hit"
+run_on_slot_enable = "AttackHit"
 require_slots_all = ["BowHit"]
 action = "PlayAudio"
 volume = 0.15

--- a/assets/animations/spider/big/tier1/Sparks.anim.toml
+++ b/assets/animations/spider/big/tier1/Sparks.anim.toml
@@ -14,9 +14,31 @@ asset_key = "audio.game.SpiderGetDamage"
 
 [[script]]
 run_on_slot_enable = "Hit"
+forbid_slots_all = ["SwordHit", "HammerHit", "BowHit"]
 action = "PlayAudio"
 volume = 0.15
 asset_key = "audio.game.ImpactBass"
+
+[[script]]
+run_on_slot_enable = "Hit"
+require_slots_all = ["SwordHit"]
+action = "PlayAudio"
+volume = 0.15
+asset_key = "audio.game.SwordImpact"
+
+[[script]]
+run_on_slot_enable = "Hit"
+require_slots_all = ["HammerHit"]
+action = "PlayAudio"
+volume = 0.15
+asset_key = "audio.game.HammerImpact"
+
+[[script]]
+run_on_slot_enable = "Hit"
+require_slots_all = ["BowHit"]
+action = "PlayAudio"
+volume = 0.15
+asset_key = "audio.game.BowImpact"
 
 # keep looping final frame
 [[script]]

--- a/assets/audio.assets.ron
+++ b/assets/audio.assets.ron
@@ -105,6 +105,24 @@
             "audio/attack/ImpactBass2.flac",
         ],
     ),
+    "audio.game.SwordImpact": Files (
+        paths: [
+            "audio/attack/ImpactBass1.flac",
+            "audio/attack/ImpactBass2.flac",
+        ],
+    ),
+    "audio.game.HammerImpact": Files (
+        paths: [
+            "audio/attack/ImpactBass1.flac",
+            "audio/attack/ImpactBass2.flac",
+        ],
+    ),
+    "audio.game.BowImpact": Files (
+        paths: [
+            "audio/attack/ImpactBass1.flac",
+            "audio/attack/ImpactBass2.flac",
+        ],
+    ),
     "audio.game.BigSpiderSteps": Files (
         paths: [
             "audio/spider/BigSpiderStep1.flac",

--- a/assets/audio.assets.ron
+++ b/assets/audio.assets.ron
@@ -107,20 +107,32 @@
     ),
     "audio.game.SwordImpact": Files (
         paths: [
-            "audio/attack/ImpactBass1.flac",
-            "audio/attack/ImpactBass2.flac",
+            "audio/attack/SwordImpact1.flac",
+            "audio/attack/SwordImpact2.flac",
+            "audio/attack/SwordImpact3.flac",
+            "audio/attack/SwordImpact4.flac",
         ],
     ),
     "audio.game.HammerImpact": Files (
         paths: [
-            "audio/attack/ImpactBass1.flac",
-            "audio/attack/ImpactBass2.flac",
+            "audio/attack/HammerImpact1.flac",
+            "audio/attack/HammerImpact2.flac",
+            "audio/attack/HammerImpact3.flac",
+            "audio/attack/HammerImpact4.flac",
         ],
     ),
     "audio.game.BowImpact": Files (
         paths: [
             "audio/attack/ImpactBass1.flac",
             "audio/attack/ImpactBass2.flac",
+        ],
+    ),
+    "audio.game.PlayerGetsDamaged": Files (
+        paths: [
+            "audio/fx/PlayerGetsDamaged1.flac",
+            "audio/fx/PlayerGetsDamaged2.flac",
+            "audio/fx/PlayerGetsDamaged3.flac",
+            "audio/fx/PlayerGetsDamaged4.flac",
         ],
     ),
     "audio.game.BigSpiderSteps": Files (

--- a/assets/audio/attack/HammerImpact1.flac
+++ b/assets/audio/attack/HammerImpact1.flac
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:de75473cb952b80bf635b02af9edc71a2da37ea419a937811672bc785bbed748
+size 33683

--- a/assets/audio/attack/HammerImpact2.flac
+++ b/assets/audio/attack/HammerImpact2.flac
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:510c4621c2dd35af8efc7e7d1e779f47d08d7ac1c7e51ae93a0159a8c036f963
+size 32436

--- a/assets/audio/attack/HammerImpact3.flac
+++ b/assets/audio/attack/HammerImpact3.flac
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d2f5e72a10254972ba440541a3bd118909f90c447d08489bef9693261de4ea4c
+size 32021

--- a/assets/audio/attack/HammerImpact4.flac
+++ b/assets/audio/attack/HammerImpact4.flac
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c71e672caa29e1d36bb9471b23707beb3a741f1260dc9cad99912c7de34a5aff
+size 31747

--- a/assets/audio/attack/SwordImpact1.flac
+++ b/assets/audio/attack/SwordImpact1.flac
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:444d112fb9190847b206bebdbd89c19a31d0dbf17d6e6e95deeab9e4d9cf8f58
+size 42840

--- a/assets/audio/attack/SwordImpact2.flac
+++ b/assets/audio/attack/SwordImpact2.flac
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:88c4b90081e2051a217f30d19f80ce60f208d19cddccd7626f0fe71dea7fcf49
+size 42063

--- a/assets/audio/attack/SwordImpact3.flac
+++ b/assets/audio/attack/SwordImpact3.flac
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:336eed07ebabf30a14d61557b8c08e0716136ac741ea6305a0dfd7bca1e5e343
+size 41456

--- a/assets/audio/attack/SwordImpact4.flac
+++ b/assets/audio/attack/SwordImpact4.flac
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:88ed91403ccdfd0265fbaec028b3f0bb47c485b4aa66c1702e96afdee8c4fa97
+size 37597

--- a/assets/audio/fx/PlayerGetsDamaged1.flac
+++ b/assets/audio/fx/PlayerGetsDamaged1.flac
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:395942baf32773bb3d883644adf0e1f8e85197e77d01684638ce239001eb930c
+size 16560

--- a/assets/audio/fx/PlayerGetsDamaged2.flac
+++ b/assets/audio/fx/PlayerGetsDamaged2.flac
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bf4dcecda8ff681f999e9531b29dcd468d8ade1d1ac3f0b311b9378b95479787
+size 20101

--- a/assets/audio/fx/PlayerGetsDamaged3.flac
+++ b/assets/audio/fx/PlayerGetsDamaged3.flac
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b8b116ef5481f15c539d99bebc3ab3d2efa65dcbabad59a7a363bdadd460ce2c
+size 20777

--- a/assets/audio/fx/PlayerGetsDamaged4.flac
+++ b/assets/audio/fx/PlayerGetsDamaged4.flac
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bd06f0a7a2cd140a6a63dd6bd98714dc5aad95223c59651f99bfca0edec194c2
+size 17033

--- a/game/src/game/enemy.rs
+++ b/game/src/game/enemy.rs
@@ -1555,7 +1555,7 @@ fn enemy_sparks_on_hit_animation(
                     format!("Spark{picked_spark}").as_str(),
                     true,
                 );
-                hit_gfx.set_slot("Hit", true);
+                hit_gfx.set_slot("AttackHit", true);
                 if let Ok(direction) = player_facing_dir.get_single() {
                     match direction {
                         Facing::Right => {

--- a/game/src/game/enemy.rs
+++ b/game/src/game/enemy.rs
@@ -911,11 +911,9 @@ fn aggro(
                 transitions.push(Aggroed::new_transition(Patrolling));
             } else if matches!(range, Range::Melee) {
                 match role {
-                    Role::Melee => {
-                        transitions.push(Waiting::new_transition(
-                            MeleeAttack::default(),
-                        ))
-                    },
+                    Role::Melee => transitions.push(Waiting::new_transition(
+                        MeleeAttack::default(),
+                    )),
                     Role::Ranged => {
                         velocity.x = 0.;
                         transitions.push(Waiting::new_transition(Defense));
@@ -1526,7 +1524,7 @@ impl Plugin for EnemyAnimationPlugin {
                 // enemy_pushback_attack_animation,
                 enemy_death_animation,
                 enemy_decay_animation,
-                enemy_sparks_on_hit_animation,
+                enemy_sparks_on_hit_animation.run_if(on_event::<DamageInfo>()),
                 enemy_decay_visibility,
                 sprite_flip,
             )

--- a/game/src/game/player/player_weapon.rs
+++ b/game/src/game/player/player_weapon.rs
@@ -3,10 +3,11 @@ use bevy::prelude::{in_state, IntoSystemConfigs, Res};
 use leafwing_input_manager::prelude::ActionState;
 use strum_macros::Display;
 use theseeker_engine::assets::animation::SpriteAnimation;
-use theseeker_engine::prelude::{Added, Changed, DetectChanges, Entity, Or};
+use theseeker_engine::prelude::{on_event, Changed, Condition, DetectChanges};
 use theseeker_engine::script::ScriptPlayer;
 use theseeker_engine::time::GameTickUpdate;
 
+use crate::game::attack::DamageInfo;
 use crate::game::enemy::{EnemyEffectGfx, EnemyStateSet};
 use crate::game::player::{Player, PlayerAction};
 use crate::prelude::{App, AppState, Plugin, Query, ResMut, Resource, With};
@@ -29,7 +30,10 @@ impl Plugin for PlayerWeaponPlugin {
                     .after(EnemyStateSet::Animation)
                     .after(swap_combat_style)
                     .after(swap_melee_weapon)
-                    .run_if(should_set_weapon_hit_sfx_slot),
+                    .run_if(
+                        is_current_weapon_changed
+                            .or_else(on_event::<DamageInfo>()),
+                    ),
             )
                 .run_if(in_state(AppState::InGame)),
         );
@@ -161,7 +165,13 @@ fn swap_melee_weapon(
 
 fn set_sfx_slot(
     current_weapon: CurrentWeapon,
-    mut query: Query<&mut ScriptPlayer<SpriteAnimation>, With<EnemyEffectGfx>>,
+    mut query: Query<
+        &mut ScriptPlayer<SpriteAnimation>,
+        (
+            Changed<ScriptPlayer<SpriteAnimation>>,
+            With<EnemyEffectGfx>,
+        ),
+    >,
 ) {
     let current_weapon_name = current_weapon.to_string();
     if current_weapon_name.is_empty() {
@@ -174,18 +184,6 @@ fn set_sfx_slot(
     }
 }
 
-fn should_set_weapon_hit_sfx_slot(
-    current_weapon: CurrentWeapon,
-    query: Query<
-        Entity,
-        Or<(
-            Added<EnemyEffectGfx>,
-            (
-                Changed<ScriptPlayer<SpriteAnimation>>,
-                With<EnemyEffectGfx>,
-            ),
-        )>,
-    >,
-) -> bool {
-    current_weapon.is_changed() || !query.is_empty()
+fn is_current_weapon_changed(current_weapon: CurrentWeapon) -> bool {
+    current_weapon.is_changed()
 }

--- a/game/src/game/player/player_weapon.rs
+++ b/game/src/game/player/player_weapon.rs
@@ -3,7 +3,9 @@ use bevy::prelude::{in_state, IntoSystemConfigs, Res};
 use leafwing_input_manager::prelude::ActionState;
 use strum_macros::Display;
 use theseeker_engine::assets::animation::SpriteAnimation;
-use theseeker_engine::prelude::{on_event, Changed, Condition, DetectChanges};
+use theseeker_engine::prelude::{
+    on_event, Changed, Commands, Condition, DetectChanges, OnEnter,
+};
 use theseeker_engine::script::ScriptPlayer;
 use theseeker_engine::time::GameTickUpdate;
 
@@ -18,9 +20,13 @@ pub(crate) struct PlayerWeaponPlugin;
 
 impl Plugin for PlayerWeaponPlugin {
     fn build(&self, app: &mut App) {
-        app.insert_resource(PlayerMeleeWeapon::default());
-        app.insert_resource(PlayerRangedWeapon::default());
-        app.insert_resource(PlayerCombatStyle::default());
+        app.init_resource::<PlayerMeleeWeapon>();
+        app.init_resource::<PlayerRangedWeapon>();
+        app.init_resource::<PlayerCombatStyle>();
+        app.add_systems(
+            OnEnter(AppState::InGame),
+            initialize_resources,
+        );
         app.add_systems(
             GameTickUpdate,
             (
@@ -133,6 +139,12 @@ impl std::fmt::Display for CurrentWeapon<'_> {
         };
         write!(f, "{weapon}")
     }
+}
+
+fn initialize_resources(mut commands: Commands) {
+    commands.insert_resource(PlayerMeleeWeapon::default());
+    commands.insert_resource(PlayerRangedWeapon::default());
+    commands.insert_resource(PlayerCombatStyle::default());
 }
 
 fn swap_combat_style(


### PR DESCRIPTION
Fixes #182 

- Added hit sound assets for each weapon type. A generic one was also kept in case the weapon-based flags are not set.
- Implemented said placeholder sounds based on the current weapon that the player is wielding.
- Renamed "Hit" slot in `Sparks.anim.toml` to "AttackHit".
- Optimized `enemy_sparks_on_hit_animation` to run only when there are relevant events to read.
- Added SFX assets for player receiving damage.