### PR TITLE
Audio improvements: support labeling, stopping, looping

### DIFF
--- a/doc/src/tech/script-ref.md
+++ b/doc/src/tech/script-ref.md
@@ -701,6 +701,15 @@ volume = 0.5
 pan = -0.25
 ```
 
+```toml
+[[script]]
+run_at_tick = 0
+action = "PlayAudio"
+asset_key = "sound.footsteps"
+volume = 0.25
+label = "Footsteps"
+```
+
 Plays the given audio asset in a manner that is precisely timed according
 to the script action's trigger condition.
 
@@ -713,6 +722,10 @@ etc, use `"PlayBackgroundAudio"` instead.
 
 The `volume` and `pan` options default to `1.0` and `0.0`, respectively.
 Pan ranges from `-1.0` (fully to the left) to `1.0` (fully to the right).
+
+The `label` option can be used to assign a string label to the sound. This is
+useful if you would like to later stop the sound using a `StopBackgroundAudio`
+script action.
 
 </details>
 
@@ -728,7 +741,16 @@ Example:
 run_on_slot_enable = "Play"
 action = "PlayBackgroundAudio"
 asset_key = "sound.mymusic"
+```
+
+```toml
+[[script]]
+run_at_tick = 100
+action = "PlayBackgroundAudio"
+asset_key = "sound.mymusic2"
 volume = 0.25
+loop = true
+label = "ExtraAmbience"
 ```
 
 Plays the given audio asset independently of any precisely timed sounds.
@@ -738,7 +760,127 @@ not need to be precisely timed.
 
 If you want precise timing, use the `"PlayAudio"` action instead.
 
-The `volume` and option defaults to `1.0`. Panning is not supported.
+The `volume` option defaults to `1.0`. Panning is not supported.
+
+The `loop` option will make the audio loop indefinitely, instead of stopping
+when finished.  Defaults to `false`.
+
+The `label` option can be used to assign a string label to the sound. This is
+useful if you would like to later stop the sound using a `StopBackgroundAudio`
+script action.
+
+</details>
+
+<details>
+  <summary>
+  <code>StopAudio</code>
+  </summary>
+
+Example:
+
+```toml
+# Stops all sounds started by the current script
+[[script]]
+run_on_playback_control = "Stop"
+action = "StopAudio"
+```
+
+```toml
+# Stops all sounds (that use precise timing)
+[[script]]
+run_on_playback_control = "Stop"
+action = "StopAudio"
+current_script_only = false
+```
+
+```toml
+# Stops all sounds labeled "Footsteps" that were started by the current script
+[[script]]
+run_on_playback_control = "Stop"
+action = "StopAudio"
+label = "Footsteps"
+```
+
+```toml
+# Stops all sounds labeled "Attacks", regardless of how they were started
+[[script]]
+run_on_slot_enable = "MySlot"
+action = "StopAudio"
+current_script_only = false
+label = "Attacks"
+```
+
+Stops sounds that were played using the precise timing system (e.g by a
+`PlayAudio` script action).
+
+The selection of which sounds to stop can be controlled by the
+`current_script_only` and `label` options.
+
+`current_script_only` defaults to `true`. If `true`, only sounds started by
+the current run of the script will be stopped. Sounds that were started by
+other scripts, previous runs of the current script, or Rust code, will not
+be affected. If `false`, all sounds will be considered, regardless of how
+they were started.
+
+`label` can be used to specify a specific label string. If set, only sounds
+with that label will be stopped.
+
+</details>
+
+<details>
+  <summary>
+  <code>StopBackgroundAudio</code>
+  </summary>
+
+Example:
+
+```toml
+# Stops all background sounds started by the current script
+[[script]]
+run_on_playback_control = "Stop"
+action = "StopBackgroundAudio"
+```
+
+```toml
+# Stops all background sounds, regardless of how they were started
+[[script]]
+run_on_playback_control = "Stop"
+action = "StopBackgroundAudio"
+current_script_only = false
+```
+
+```toml
+# Stops all sounds labeled "Music" that were started by the current script
+[[script]]
+run_on_playback_control = "Stop"
+action = "StopBackgroundAudio"
+label = "Music"
+```
+
+```toml
+# Stops all sounds labeled "ExtraAmbience", regardless of how they were started
+[[script]]
+run_on_slot_enable = "MySlot"
+action = "StopBackgroundAudio"
+current_script_only = false
+label = "ExtraAmbience"
+```
+
+Stops background sounds (that do not use the precise timing system).
+This applies to sounds started with the `PlayBackgroundAudio` script action,
+as well as any sounds played using `bevy_audio` entities in Rust code.
+
+The selection of which sounds to stop can be controlled by the
+`current_script_only` and `label` options.
+
+`current_script_only` defaults to `true`. If `true`, only sounds started by
+the current run of the script will be stopped. Sounds that were started by
+other scripts, previous runs of the current script, or Rust code, will not
+be affected. If `false`, all sounds will be considered, regardless of how
+they were started.
+
+`label` can be used to specify a specific label string. If set, only sounds
+with that label will be stopped.
 
 </details>
 

--- a/engine/src/assets/script.rs
+++ b/engine/src/assets/script.rs
@@ -154,13 +154,32 @@ pub enum CommonScriptAction {
     /// Play a sound (precise timing based on action's trigger condition)
     PlayAudio {
         asset_key: String,
+        label: Option<String>,
         volume: Option<f32>,
         pan: Option<f32>,
+    },
+    /// Stop sounds that are currently playing
+    StopAudio {
+        /// If true (default), only apply to sounds started by the current script.
+        /// If false, apply to sounds started from anywhere.
+        current_script_only: Option<bool>,
+        /// Only stop sounds with the given label. If unset, stop all sounds.
+        label: Option<String>,
     },
     /// Play a sound (using regular bevy audio, not our precise system)
     PlayBackgroundAudio {
         asset_key: String,
+        label: Option<String>,
         volume: Option<f32>,
+        r#loop: Option<bool>,
+    },
+    /// Stop sounds that are currently playing
+    StopBackgroundAudio {
+        /// If true (default), only apply to sounds started by the current script.
+        /// If false, apply to sounds started from anywhere.
+        current_script_only: Option<bool>,
+        /// Only stop sounds with the given label. If unset, stop all sounds.
+        label: Option<String>,
     },
 }
 

--- a/engine/src/audio.rs
+++ b/engine/src/audio.rs
@@ -4,6 +4,8 @@ use crate::prelude::*;
 
 mod mixer;
 
+pub use mixer::PreciseAudioId;
+
 pub struct AudioPlugin;
 
 impl Plugin for AudioPlugin {
@@ -49,4 +51,9 @@ impl Decodable for PrecisionMixerInstance {
     fn decoder(&self) -> Self::Decoder {
         mixer::PrecisionMixer::new(self.controller.clone())
     }
+}
+
+#[derive(Component)]
+pub struct LabeledBackgroundSound {
+    pub label: String,
 }


### PR DESCRIPTION
This PR adds some new features to audio scripting:

 * The `PlayBackgroundAudio` action now has a `loop` parameter, which can make the audio loop from the beginning instead of stopping when finished.
 * The `PlayAudio` and `PlayBackgroundAudio` now support a `label` parameter, which can be used to associate the sound with a string label. This is useful for identifying sounds and for grouping related sounds.
 * New `StopAudio` and `StopBackgroundAudio` actions for stopping sounds that might be currently playing. The selection of which sounds to stop can be done by label. It is also possible to choose whether only sounds that were started by the current run of the current script will be considered, or all sounds.
 
 Examples:
 
 ```toml
[[script]]
run_at_tick = 0
action = "PlayAudio"
asset_key = "sound.footsteps"
volume = 0.25
label = "Footsteps"
```

```toml
[[script]]
run_at_tick = 100
action = "PlayBackgroundAudio"
asset_key = "sound.mymusic2"
volume = 0.25
loop = true
label = "ExtraAmbience"
```

```toml
# Stops all sounds started by the current script
[[script]]
run_on_playback_control = "Stop"
action = "StopAudio"
current_script_only = true # can be omitted, defaults to `true`
```

```toml
# Stops all sounds (that use precise timing)
[[script]]
run_on_playback_control = "Stop"
action = "StopAudio"
current_script_only = false
```

```toml
# Stops all sounds labeled "Footsteps" that were started by the current script
[[script]]
run_on_playback_control = "Stop"
action = "StopAudio"
label = "Footsteps"
```

```toml
# Stops all sounds labeled "Attacks", regardless of how they were started
[[script]]
run_on_slot_enable = "MySlot"
action = "StopAudio"
current_script_only = false
label = "Attacks"
```

```toml
# Stops all background sounds started by the current script
[[script]]
run_on_playback_control = "Stop"
action = "StopBackgroundAudio"
```

```toml
# Stops all background sounds, regardless of how they were started
[[script]]
run_on_playback_control = "Stop"
action = "StopBackgroundAudio"
current_script_only = false
```

```toml
# Stops all sounds labeled "Music" that were started by the current script
[[script]]
run_on_playback_control = "Stop"
action = "StopBackgroundAudio"
label = "Music"
```

```toml
# Stops all sounds labeled "ExtraAmbience", regardless of how they were started
[[script]]
run_on_slot_enable = "MySlot"
action = "StopBackgroundAudio"
current_script_only = false
label = "ExtraAmbience"
```
