### PR TITLE
Layer Ordering Fixes

### DIFF
--- a/game/src/game/enemy.rs
+++ b/game/src/game/enemy.rs
@@ -305,17 +305,28 @@ fn setup_enemy(
     mut q: Query<(
         &mut Transform,
         &Tier,
+        &Role,
         Entity,
         Ref<EnemyBlueprint>,
     )>,
     mut commands: Commands,
 ) {
-    for (mut xf_gent, tier, e_gent, bp) in q.iter_mut() {
+    for (mut xf_gent, tier, role, e_gent, bp) in q.iter_mut() {
         if !bp.is_added() {
             continue;
         }
         // TODO: ensure proper z order
         xf_gent.translation.z = 14.0 * 0.000001;
+        // Make melee spiders appear in front of ranged ones
+        if let Role::Melee = role {
+            xf_gent.translation.z += 0.0000001;
+        }
+        // Make higher tier spiders appear in front of lower tier ones
+        xf_gent.translation.z += match tier {
+            Tier::Base => 0.0,
+            Tier::Two => 0.00000001,
+            Tier::Three => 0.00000002,
+        };
         xf_gent.translation.y += 2.0; // Sprite offset so it looks like it is standing on the ground
         let health = (100 + bp.bonus_hp) * *tier as u32;
         let e_gfx = commands.spawn(()).id();

--- a/game/src/game/enemy.rs
+++ b/game/src/game/enemy.rs
@@ -1465,7 +1465,11 @@ pub fn dead(
             )>();
         }
         if dead.ticks == 8 * 7 {
-            commands.entity(entity).remove::<Dead>().insert(Decay);
+            commands
+                .entity(entity)
+                .remove::<Dead>()
+                .insert(Decay)
+                .remove_parent();
         }
         dead.ticks += 1;
     }

--- a/game/src/game/enemy.rs
+++ b/game/src/game/enemy.rs
@@ -1092,8 +1092,9 @@ fn ranged_attack(
                         InteractionGroups::new(ENEMY_ATTACK, PLAYER),
                     ),
                     TransformBundle::from(Transform::from_translation(
-                        enemy_transform.translation(),
+                        enemy_transform.translation().truncate().extend(1.0),
                     )),
+                    VisibilityBundle::default(),
                 ))
                 .with_lingering_particles(particle_effect.0.clone());
         }

--- a/game/src/game/merchant.rs
+++ b/game/src/game/merchant.rs
@@ -62,21 +62,24 @@ pub fn setup_merchant(
         println!("{:?}", xf_gent);
         let e_gfx = commands.spawn(()).id();
         let e_effects_gfx = commands.spawn_empty().id();
-        commands.entity(e_gent).insert((
-            Name::new("Merchant"),
-            Gent {
-                e_gfx,
-                e_effects_gfx,
-            },
-            Collider::cuboid(
-                40.0,
-                40.0,
-                InteractionGroups {
-                    memberships: SENSOR,
-                    filter: PLAYER,
+        commands
+            .entity(e_gent)
+            .insert((
+                Name::new("Merchant"),
+                Gent {
+                    e_gfx,
+                    e_effects_gfx,
                 },
-            ),
-        ));
+                Collider::cuboid(
+                    40.0,
+                    40.0,
+                    InteractionGroups {
+                        memberships: SENSOR,
+                        filter: PLAYER,
+                    },
+                ),
+            ))
+            .remove_parent();
         let mut player = ScriptPlayer::<SpriteAnimation>::default();
         player.play_key("anim.merchant.Idle");
         commands.entity(e_gfx).insert((

--- a/game/src/game/switches.rs
+++ b/game/src/game/switches.rs
@@ -87,21 +87,24 @@ fn setup_switches(
         let e_effects_gfx = commands.spawn_empty().id();
 
         player.play_key("anim.switch.flip");
-        commands.entity(e_gent).insert((
-            PuzzleId(id),
-            Gent {
-                e_gfx,
-                e_effects_gfx,
-            },
-            Collider::cuboid(
-                30.0,
-                30.0,
-                InteractionGroups {
-                    memberships: SENSOR,
-                    filter: PLAYER,
+        commands
+            .entity(e_gent)
+            .insert((
+                PuzzleId(id),
+                Gent {
+                    e_gfx,
+                    e_effects_gfx,
                 },
-            ),
-        ));
+                Collider::cuboid(
+                    30.0,
+                    30.0,
+                    InteractionGroups {
+                        memberships: SENSOR,
+                        filter: PLAYER,
+                    },
+                ),
+            ))
+            .remove_parent();
         commands.entity(e_gfx).insert((
             SwitchGfxBundle {
                 marker: SwitchGfx { e_gent },

--- a/game/src/game/xp_orbs.rs
+++ b/game/src/game/xp_orbs.rs
@@ -40,7 +40,7 @@ fn spawn_orbs_on_death(
     let size = Vec2::splat(2.0);
 
     for tr in enemy_q.iter() {
-        let translation = tr.translation();
+        let enemy_pos = tr.translation().truncate();
 
         let mut rng = rand::thread_rng();
 
@@ -52,7 +52,7 @@ fn spawn_orbs_on_death(
                 rng.gen_range(-POS_RADIUS..POS_RADIUS),
             )
             .clamp_length_max(POS_RADIUS);
-
+            let orb_position = enemy_pos + pos;
             let vel = pos * 0.25;
             let color: Color = if let Ok(passives) = player_q.get_single() {
                 if passives.contains(&Passive::Bloodstone) {
@@ -74,7 +74,7 @@ fn spawn_orbs_on_death(
                         ..default()
                     },
                     transform: Transform::from_translation(
-                        translation + pos.extend(0.),
+                        orb_position.extend((15.0 * 0.000001) - 0.0000001),
                     ),
                     ..default()
                 },

--- a/game/src/game/yak.rs
+++ b/game/src/game/yak.rs
@@ -48,7 +48,10 @@ pub fn setup_yak(
         xf_gent.translation.y += 5.0;
         println!("{:?}", xf_gent);
         let e_gfx = commands.spawn(()).id();
-        commands.entity(e_gent).insert((Name::new("Yak"),));
+        commands
+            .entity(e_gent)
+            .insert(Name::new("Yak"))
+            .remove_parent();
         let mut player = ScriptPlayer::<SpriteAnimation>::default();
         player.play_key("anim.yak.Idle");
         commands.entity(e_gfx).insert((


### PR DESCRIPTION
Fixes #188 

- Switches render behind walls properly.
- Merchant and yak now render behind the player.
- Dead enemies are now rendered behind all other creatures.
- Xp orbs are now rendered over walls (but behind the player).
- Enemy projectiles are now rendered over walls (and will stop outputting visibility related warnings).
- Spider enemies are z sorted based on their `Role` (melee>ranged) and `Tier` (higher tier>lower tier).