### PR TITLE
Downward Attack

### DIFF
--- a/assets/animations/player/hammer/BasicAir.anim.toml
+++ b/assets/animations/player/hammer/BasicAir.anim.toml
@@ -18,6 +18,14 @@ action = "PlayAudio"
 volume = 0.5
 asset_key = "audio.game.XpOrbs"
 
+# Downward Attack
+[[script]]
+run_on_playback_control = "Start"
+require_slots_all = ["DownwardAttack"]
+forbid_slots_all = ["AttackTransition"]
+action = "SetFrameNow"
+frame_index = 13
+
 # I set the start frame to 7 which is the regular forward attack while in air.
 # The last frame index of the regular forward attack is 12
 # Then for the 'pogo' (downward) air attack, the start frame index is 13 and end is 18
@@ -31,7 +39,7 @@ ticks_per_frame = 6
 
 
 [[script]]
-run_at_frame = [7]
+run_at_frame = [7, 13]
 forbid_slots_all = ["AttackTransition"]
 action = "PlayAudio"
 volume = 0.5

--- a/assets/animations/player/sword/BasicAir.anim.toml
+++ b/assets/animations/player/sword/BasicAir.anim.toml
@@ -19,17 +19,46 @@ volume = 0.5
 asset_key = "audio.game.XpOrbs"
 
 [[script]]
-run_at_frame = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20]
+run_at_frame = [
+    1,
+    2,
+    3,
+    4,
+    5,
+    6,
+    7,
+    8,
+    9,
+    10,
+    11,
+    12,
+    13,
+    14,
+    15,
+    16,
+    17,
+    18,
+    19,
+    20,
+]
 require_slots_any = ["SerpentRing", "FrenziedAttack"]
 action = "SetTicksPerFrame"
 ticks_per_frame = 6
 
 [[script]]
-run_at_frame = [2, 7, 12]
+run_at_frame = [2, 7, 12, 16]
 forbid_slots_all = ["AttackTransition"]
 action = "PlayAudio"
 volume = 0.5
 asset_key = "audio.game.SwordSlash"
+
+# Downward Attack
+[[script]]
+run_on_playback_control = "Start"
+require_slots_all = ["DownwardAttack"]
+forbid_slots_all = ["AttackTransition"]
+action = "SetFrameNow"
+frame_index = 16
 
 # play the last frame again if the animation hasnt ended so we dont roll over into next variant
 [[script]]

--- a/game/src/game/attack/mod.rs
+++ b/game/src/game/attack/mod.rs
@@ -142,16 +142,14 @@ impl Attack {
         self
     }
 
-    pub fn with_damage(mut self, damage: f32) -> Self {
-        self.damage = damage;
-        self
-    }
-
     pub fn with_max_targets(mut self, max_targets: u32) -> Self {
         self.max_targets = max_targets;
         self
     }
 }
+
+#[derive(Component)]
+pub struct DownwardAttack;
 
 /// Event sent when damage is applied
 #[derive(Event, Clone, Copy, PartialEq)]

--- a/game/src/game/player/mod.rs
+++ b/game/src/game/player/mod.rs
@@ -578,10 +578,6 @@ impl Dashing {
         self.dash_type == DashType::Downward
     }
 
-    pub fn is_horizontal_dash(&self) -> bool {
-        self.dash_type == DashType::Horizontal
-    }
-
     pub fn set_player_velocity(
         &self,
         velocity: &mut LinearVelocity,
@@ -701,6 +697,12 @@ pub struct CoyoteTime(f32);
 
 #[derive(Component, Default, Debug)]
 pub struct JumpCount(u8);
+
+impl JumpCount {
+    pub fn reset(&mut self) {
+        self.0 = 2;
+    }
+}
 
 /// Indicates that sliding is tracked for this entity
 #[derive(Component, Default, Debug)]

--- a/game/src/game/player/player_behaviour.rs
+++ b/game/src/game/player/player_behaviour.rs
@@ -29,7 +29,6 @@ use crate::game::pickups::{
     PassiveDescriptionNode, PassiveEntity, PickupDrop, PickupHint, PickupType,
     PICKUP_RANGE_SQUARED,
 };
-use crate::game::player::Passive;
 use crate::game::player::{
     Attacking, CanAttack, CanDash, CoyoteTime, Dashing, Falling, Grounded,
     HitFreezeTime, Idle, Jumping, Player, PlayerAction, PlayerConfig,
@@ -1479,32 +1478,8 @@ pub fn player_whirl(
                 }
             // if there is no attack, spawn a new one
             } else {
-                // Determine collider lifetime based on melee weapon and passives:
-                // For Sword: default = 16, if (SerpentRing or FrenziedAttack) active then 12
-                // For Hammer: default = 24, if (SerpentRing or FrenziedAttack) active then 18
-                let lifetime = if *melee_weapon == PlayerMeleeWeapon::Hammer {
-                    if passives.contains(&Passive::SerpentRing)
-                        || passives.contains(&Passive::FrenziedAttack)
-                    {
-                        18
-                    } else {
-                        24
-                    }
-                } else {
-                    if passives.contains(&Passive::SerpentRing)
-                        || passives.contains(&Passive::FrenziedAttack)
-                    {
-                        12
-                    } else {
-                        16
-                    }
-                };
-
-                let damage = if *melee_weapon == PlayerMeleeWeapon::Hammer {
-                    51.0
-                } else {
-                    33.0
-                } * stat_mod.attack;
+                let lifetime = melee_weapon.attack_lifetime(passives);
+                let damage = melee_weapon.base_damage() * stat_mod.attack;
                 let new_attack = commands
                     .spawn((
                         AttackBundle {

--- a/game/src/game/player/player_behaviour.rs
+++ b/game/src/game/player/player_behaviour.rs
@@ -29,6 +29,7 @@ use crate::game::pickups::{
     PassiveDescriptionNode, PassiveEntity, PickupDrop, PickupHint, PickupType,
     PICKUP_RANGE_SQUARED,
 };
+use crate::game::player::Passive;
 use crate::game::player::{
     Attacking, CanAttack, CanDash, CoyoteTime, Dashing, Falling, Grounded,
     HitFreezeTime, Idle, Jumping, Player, PlayerAction, PlayerConfig,
@@ -38,7 +39,6 @@ use crate::prelude::*;
 use crate::ui::popup::{PopupTimer, PopupUi};
 use crate::StateDespawnMarker;
 use crate::{camera::CameraShake, game::player::PlayerStatMod};
-use crate::game::player::Passive;
 
 /// Player behavior systems.
 /// Do stuff here in states and add transitions to other states by pushing
@@ -1192,6 +1192,7 @@ fn player_attack(
             &ActionState<PlayerAction>,
             &PlayerStatMod,
             Has<Stealthing>,
+            Has<Grounded>,
         ),
         (With<Player>, Without<Whirling>),
     >,
@@ -1213,6 +1214,7 @@ fn player_attack(
         action_state,
         stat_mod,
         stealthed,
+        grounded,
     ) in query.iter_mut()
     {
         if attacking.ticks == 0 {
@@ -1318,32 +1320,41 @@ fn player_attack(
                         );
                     }
 
-                    commands
-                        .spawn((
-                            TransformBundle::from_transform(
-                                Transform::from_xyz(0.0, 0.0, 0.0),
-                            ),
-                            AnimationCollider(gent.e_gfx),
-                            // TODO: ? ColliderMeta
-                            Collider::empty(InteractionGroups::new(
-                                PLAYER_ATTACK,
-                                ENEMY_HURT,
-                            )),
-                            Attack::new(16, entity, damage * stat_mod.attack),
-                            SelfPushback(Knockback::new(
-                                Vec2::new(
-                                    self_pushback * -facing.direction(),
-                                    0.,
-                                ),
-                                self_pushback_ticks,
-                            )),
-                            Pushback(Knockback::new(
+                    let is_attacking_downwards =
+                        !grounded && action_state.pressed(&PlayerAction::Fall);
+                    let self_knockback_strength = if is_attacking_downwards {
+                        Vec2::new(0.0, self_pushback)
+                    } else {
+                        Vec2::new(self_pushback * -facing.direction(), 0.)
+                    };
+                    let mut attack_entity_commands = commands.spawn((
+                        TransformBundle::from_transform(Transform::from_xyz(
+                            0.0, 0.0, 0.0,
+                        )),
+                        AnimationCollider(gent.e_gfx),
+                        // TODO: ? ColliderMeta
+                        Collider::empty(InteractionGroups::new(
+                            PLAYER_ATTACK,
+                            ENEMY_HURT,
+                        )),
+                        Attack::new(16, entity, damage * stat_mod.attack),
+                        SelfPushback(Knockback::new(
+                            self_knockback_strength,
+                            self_pushback_ticks,
+                        )),
+                    ));
+                    attack_entity_commands.set_parent(entity);
+
+                    if !is_attacking_downwards {
+                        attack_entity_commands.insert(Pushback(
+                            Knockback::new(
                                 Vec2::new(facing.direction() * pushback, 0.),
                                 pushback_ticks,
-                            )),
-                        ))
-                        .set_parent(entity)
-                        .id()
+                            ),
+                        ));
+                    }
+
+                    attack_entity_commands.id()
                 },
             };
 
@@ -1413,7 +1424,7 @@ pub fn player_whirl(
             &PlayerStatMod,
             Has<Stealthing>,
             &Gent,
-            &Passives
+            &Passives,
         ),
         (
             With<Player>,
@@ -1472,27 +1483,40 @@ pub fn player_whirl(
                 // For Sword: default = 16, if (SerpentRing or FrenziedAttack) active then 12
                 // For Hammer: default = 24, if (SerpentRing or FrenziedAttack) active then 18
                 let lifetime = if *melee_weapon == PlayerMeleeWeapon::Hammer {
-                    if passives.contains(&Passive::SerpentRing) || passives.contains(&Passive::FrenziedAttack) {
+                    if passives.contains(&Passive::SerpentRing)
+                        || passives.contains(&Passive::FrenziedAttack)
+                    {
                         18
                     } else {
                         24
                     }
                 } else {
-                    if passives.contains(&Passive::SerpentRing) || passives.contains(&Passive::FrenziedAttack) {
+                    if passives.contains(&Passive::SerpentRing)
+                        || passives.contains(&Passive::FrenziedAttack)
+                    {
                         12
                     } else {
                         16
                     }
                 };
 
-                let damage = if *melee_weapon == PlayerMeleeWeapon::Hammer { 51.0 } else { 33.0 } * stat_mod.attack;
+                let damage = if *melee_weapon == PlayerMeleeWeapon::Hammer {
+                    51.0
+                } else {
+                    33.0
+                } * stat_mod.attack;
                 let new_attack = commands
                     .spawn((
                         AttackBundle {
                             attack: Attack::new(lifetime, entity, damage),
-                            collider: Collider::empty(InteractionGroups::new(PLAYER_ATTACK, ENEMY_HURT)),
+                            collider: Collider::empty(InteractionGroups::new(
+                                PLAYER_ATTACK,
+                                ENEMY_HURT,
+                            )),
                         },
-                        TransformBundle::from_transform(Transform::from_xyz(0.0, 0.0, 0.0)),
+                        TransformBundle::from_transform(Transform::from_xyz(
+                            0.0, 0.0, 0.0,
+                        )),
                         AnimationCollider(gent.e_gfx),
                     ))
                     .set_parent(entity)

--- a/game/src/game/player/player_weapon.rs
+++ b/game/src/game/player/player_weapon.rs
@@ -8,7 +8,7 @@ use theseeker_engine::time::GameTickUpdate;
 use crate::game::player::{Player, PlayerAction};
 use crate::prelude::{App, AppState, Plugin, Query, ResMut, Resource, With};
 
-use super::{PlayerConfig, PlayerStateSet};
+use super::{Passive, Passives, PlayerConfig, PlayerStateSet};
 
 pub(crate) struct PlayerWeaponPlugin;
 
@@ -53,6 +53,39 @@ pub enum PlayerMeleeWeapon {
 }
 
 impl PlayerMeleeWeapon {
+    /// Returns the attack collider lifetime based on melee weapon and passives:
+    /// For Sword: default = 16, if (SerpentRing or FrenziedAttack) active then 12
+    /// For Hammer: default = 24, if (SerpentRing or FrenziedAttack) active then 18
+    pub fn attack_lifetime(&self, passives: &Passives) -> u32 {
+        let has_serpent_ring_or_frenzied_attack = passives
+            .contains(&Passive::SerpentRing)
+            || passives.contains(&Passive::FrenziedAttack);
+
+        match self {
+            Self::Hammer => {
+                if has_serpent_ring_or_frenzied_attack {
+                    18
+                } else {
+                    24
+                }
+            },
+            Self::Sword => {
+                if has_serpent_ring_or_frenzied_attack {
+                    12
+                } else {
+                    16
+                }
+            },
+        }
+    }
+
+    pub fn base_damage(&self) -> f32 {
+        match self {
+            Self::Hammer => 51.0,
+            Self::Sword => 33.0,
+        }
+    }
+
     pub fn pushback_values(&self, config: &PlayerConfig) -> PushbackValues {
         let (pushback, pushback_ticks, self_pushback, self_pushback_ticks) =
             match self {


### PR DESCRIPTION
Fixes #153 

- Updated animation scripts to support downward attacks.
- Implemented downward attacks that pushes the player upwards on hit and resets the jump counter.
- Refactored `player_whirl` code to fix lints and for future proofing.