### PR TITLE
Fix Dash direction during Bow Auto Aim

### DIFF
--- a/game/src/game/player/player_behaviour.rs
+++ b/game/src/game/player/player_behaviour.rs
@@ -60,9 +60,12 @@ impl Plugin for PlayerBehaviorPlugin {
                     player_whirl_charge.before(player_whirl),
                     (
                         player_whirl,
-                        bow_auto_aim.after(player_move).run_if(
-                            resource_equals(PlayerCombatStyle::Ranged),
-                        ),
+                        bow_auto_aim
+                            .after(player_move)
+                            .after(player_dash)
+                            .run_if(resource_equals(
+                                PlayerCombatStyle::Ranged,
+                            )),
                     )
                         .before(player_attack),
                     player_attack.run_if(any_with_component::<Attacking>),


### PR DESCRIPTION
- Ordered `bow_auto_aim` after `player_dash` so the dash takes the facing direction set by the `player_move` system.