### PR TITLE
Switched to single runtime and updated to Rust 2024 edition to fix #205

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "theseeker"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/game/src/game/enemy.rs
+++ b/game/src/game/enemy.rs
@@ -689,7 +689,7 @@ enum Role {
 impl Role {
     fn random() -> Role {
         let mut rng = rand::thread_rng();
-        rng.gen()
+        rng.r#gen()
     }
 }
 


### PR DESCRIPTION
This updates TheSeeker to Rust 2024 Edition
Fixes #205

2021 -> 2024 is constantly changing because of Rust constant changes.  
With changes, unfortunately, breaking changes updating from rust 2021 -> 2024 will be more and more difficult. 

Frame drops were caused by 2 runtimes, old_runtime and runtime.
I updated to Rust 2024 Edition and switched to one runtime to fix frame drops. Result is game is a lot smoother, feels a lot more polished fixing frame drops.